### PR TITLE
feat: Add unihiker expansion board motor drive

### DIFF
--- a/.github/workflows/skill-validation.yml
+++ b/.github/workflows/skill-validation.yml
@@ -26,7 +26,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Check formatting with oxfmt
-        run: pnpm exec oxfmt --check .
+        run: pnpm exec oxfmt --check
 
       - name: Validate skills
         run: pnpm validate-skills

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -2,15 +2,5 @@
   "$schema": "./node_modules/oxfmt/configuration_schema.json",
   "semi": false,
   "singleQuote": true,
-  "overrides": [
-    {
-      "files": ["skills/**/*.md"],
-      "options": {
-        "semi": false,
-        "trailingComma": "none",
-        "singleQuote": false
-      }
-    }
-  ],
-  "ignorePatterns": [".vscode/**/*.json"]
+  "ignorePatterns": [".vscode/**/*.json", "skills/**/*.md"]
 }

--- a/skills/unihiker_expansion_motor_control/SKILL.md
+++ b/skills/unihiker_expansion_motor_control/SKILL.md
@@ -1,0 +1,68 @@
+---
+{
+  "name": "unihiker_expansion_motor_control",
+  "description": "Control DFRobot UNIHIKER Expansion board(DFR1261) motors over I2C.",
+  "author": "YeezB",
+  "metadata":
+    {
+      "category": ["sensor"],
+      "tags": ["motor", "unihiker", "dfrobot", "expansion board"],
+      "peripherals": [],
+      "cap_groups": ["cap_lua"],
+      "manage_mode": "web"
+    }
+}
+---
+
+# UNIHIKER Expansion Motor Control
+
+Use this skill to control motors on a DFRobot UNIHIKER Expansion board (SKU: DFR1216). Chinese name is 行空板扩展板.
+
+Run exactly one script with `lua_run_script`.
+
+If `lua_run_script` returns an error, report that error directly to the user.
+Do not retry with changed arguments in the same turn unless the user explicitly asks.
+
+## Tool Call Inputs
+
+Stop all motors:
+
+```json
+{"path":"{CUR_SKILL_DIR}/scripts/set_motor.lua","args":{"stop_all":true}}
+```
+
+Drive motor1 forward:
+
+```json
+{"path":"{CUR_SKILL_DIR}/scripts/set_motor.lua","args":{"period_12":255,"duty":{"m1_a":255,"m1_b":0}}}
+```
+
+Drive motor1 reverse:
+
+```json
+{"path":"{CUR_SKILL_DIR}/scripts/set_motor.lua","args":{"period_12":255,"duty":{"m1_a":0,"m1_b":255}}}
+```
+
+Drive four motors with mixed duty values:
+
+```json
+{"path":"{CUR_SKILL_DIR}/scripts/set_motor.lua","args":{"period_12":255,"period_34":255,"duty":{"m1_a":255,"m1_b":0,"m2_a":0,"m2_b":255,"m3_a":50,"m3_b":0,"m4_a":0,"m4_b":50}}}
+```
+
+Drive motor1 forward for 2 seconds, then auto stop:
+
+```json
+{"path":"{CUR_SKILL_DIR}/scripts/set_motor.lua","args":{"period_12":255,"auto_stop_ms":2000,"duty":{"m1_a":255,"m1_b":0}}}
+```
+
+Notes:
+- `auto_stop_ms` is optional. Default is `0` (no timer stop).
+- When `auto_stop_ms > 0`, the script waits that many milliseconds and then writes all motor duty channels to `0`.
+
+## Recommended Flow
+
+1. Confirm the expansion board is connected to an available I2C bus.
+2. Use the script defaults unless the user explicitly provides custom I2C settings.
+3. Run `{CUR_SKILL_DIR}/scripts/set_motor.lua` with desired `period_12`, `period_34`, and `duty`.
+4. If immediate emergency stop is needed, run the script with `stop_all: true`.
+5. Report script output directly to the user, including any error.

--- a/skills/unihiker_expansion_motor_control/SKILL.md
+++ b/skills/unihiker_expansion_motor_control/SKILL.md
@@ -6,8 +6,8 @@
   "metadata":
     {
       "category": ["sensor"],
-      "tags": ["motor", "unihiker", "dfrobot", "expansion board"],
-      "peripherals": [],
+      "tags": ["unihiker", "dfrobot", "expansion board"],
+      "peripherals": ["motor"],
       "cap_groups": ["cap_lua"],
       "manage_mode": "web"
     }

--- a/skills/unihiker_expansion_motor_control/scripts/set_motor.lua
+++ b/skills/unihiker_expansion_motor_control/scripts/set_motor.lua
@@ -1,0 +1,205 @@
+-- --------------------------------------------------------------
+-- DFRobot UNIHIKER Expansion motor controller over I2C.
+-- Register protocol is aligned with DFRobot_UnihikerExpansion setMotor.* APIs.
+-- --------------------------------------------------------------
+
+local i2c = require("i2c")
+local delay = require("delay")
+
+local DEFAULT_I2C_PORT = 0
+local DEFAULT_SDA = 47
+local DEFAULT_SCL = 48
+local DEFAULT_I2C_FREQ_HZ = 400000
+local DEFAULT_ADDR = 0x33
+local DEFAULT_PERIOD = 255
+local DEFAULT_AUTO_STOP_MS = 0
+
+local REG_MOTOR12_PERIOD_H = 0x00
+local REG_MOTOR34_PERIOD_H = 0x02
+local REG_MOTOR1_A_DUTY_H = 0x04
+
+local MOTOR_KEYS = {
+  "m1_a",
+  "m1_b",
+  "m2_a",
+  "m2_b",
+  "m3_a",
+  "m3_b",
+  "m4_a",
+  "m4_b",
+}
+
+local function read_arg(name, default)
+  if type(args) == "table" and args[name] ~= nil then
+    return args[name]
+  end
+  return default
+end
+
+local function parse_int_arg(name, default, min_value, max_value)
+  local value = read_arg(name, default)
+  if type(value) ~= "number" or value % 1 ~= 0 then
+    error(name .. " must be an integer")
+  end
+  if min_value ~= nil and value < min_value then
+    error(string.format("%s must be >= %d", name, min_value))
+  end
+  if max_value ~= nil and value > max_value then
+    error(string.format("%s must be <= %d", name, max_value))
+  end
+  return value
+end
+
+local function parse_bool_arg(name, default)
+  local value = read_arg(name, default)
+  if type(value) ~= "boolean" then
+    error(name .. " must be a boolean")
+  end
+  return value
+end
+
+local function parse_duty_table(stop_all)
+  local duty = {}
+  local raw = read_arg("duty", {})
+  local i
+
+  if type(raw) ~= "table" then
+    error("duty must be an object")
+  end
+
+  for _, key in ipairs(MOTOR_KEYS) do
+    duty[key] = 0
+  end
+
+  for key, value in pairs(raw) do
+    local known = false
+
+    for _, allowed_key in ipairs(MOTOR_KEYS) do
+      if key == allowed_key then
+        known = true
+        break
+      end
+    end
+
+    if not known then
+      error("unsupported duty key: " .. tostring(key))
+    end
+    if type(value) ~= "number" or value % 1 ~= 0 then
+      error("duty." .. key .. " must be an integer")
+    end
+    if value < 0 or value > 65535 then
+      error("duty." .. key .. " must be in range 0-65535")
+    end
+    duty[key] = value
+  end
+
+  if stop_all then
+    for i = 1, #MOTOR_KEYS do
+      duty[MOTOR_KEYS[i]] = 0
+    end
+  end
+
+  return duty
+end
+
+local function to_u16_bytes(value)
+  return {
+    math.floor(value / 256) % 256,
+    value % 256,
+  }
+end
+
+local function write_u16(dev, reg, value)
+  dev:write(to_u16_bytes(value), reg)
+end
+
+local function write_all_duty(dev, duty)
+  for idx, key in ipairs(MOTOR_KEYS) do
+    local reg = REG_MOTOR1_A_DUTY_H + (idx - 1) * 2
+    write_u16(dev, reg, duty[key])
+  end
+end
+
+local function build_stop_duty()
+  local duty = {}
+  for _, key in ipairs(MOTOR_KEYS) do
+    duty[key] = 0
+  end
+  return duty
+end
+
+local function run()
+  local i2c_port = parse_int_arg("i2c_port", DEFAULT_I2C_PORT, 0, 1)
+  local sda = parse_int_arg("sda", DEFAULT_SDA, 0, 63)
+  local scl = parse_int_arg("scl", DEFAULT_SCL, 0, 63)
+  local i2c_freq_hz = parse_int_arg("i2c_freq_hz", DEFAULT_I2C_FREQ_HZ, 10000, 1000000)
+  local addr = parse_int_arg("addr", DEFAULT_ADDR, 0x08, 0x77)
+  local period_12 = parse_int_arg("period_12", DEFAULT_PERIOD, 0, 65535)
+  local period_34 = parse_int_arg("period_34", DEFAULT_PERIOD, 0, 65535)
+  local stop_all = parse_bool_arg("stop_all", false)
+  local auto_stop_ms = parse_int_arg("auto_stop_ms", DEFAULT_AUTO_STOP_MS, 0, 3600000)
+  local duty = parse_duty_table(stop_all)
+
+  local bus = nil
+  local dev = nil
+
+  local ok, err = xpcall(function()
+    bus = i2c.new(i2c_port, sda, scl, i2c_freq_hz)
+    dev = bus:device(addr)
+
+    write_u16(dev, REG_MOTOR12_PERIOD_H, period_12)
+    write_u16(dev, REG_MOTOR34_PERIOD_H, period_34)
+    write_all_duty(dev, duty)
+
+    print(string.format(
+      "[unihiker_motor] ok addr=0x%02X port=%d sda=%d scl=%d freq=%d period12=%d period34=%d stop_all=%s auto_stop_ms=%d",
+      addr,
+      i2c_port,
+      sda,
+      scl,
+      i2c_freq_hz,
+      period_12,
+      period_34,
+      tostring(stop_all),
+      auto_stop_ms
+    ))
+
+    print(string.format(
+      "[unihiker_motor] duty m1(%d,%d) m2(%d,%d) m3(%d,%d) m4(%d,%d)",
+      duty.m1_a,
+      duty.m1_b,
+      duty.m2_a,
+      duty.m2_b,
+      duty.m3_a,
+      duty.m3_b,
+      duty.m4_a,
+      duty.m4_b
+    ))
+
+    if auto_stop_ms > 0 and not stop_all then
+      local stop_duty = build_stop_duty()
+
+      delay.delay_ms(auto_stop_ms)
+      write_all_duty(dev, stop_duty)
+      print(string.format("[unihiker_motor] auto stopped after %d ms", auto_stop_ms))
+    end
+  end, debug.traceback)
+
+  if dev then
+    pcall(function()
+      dev:close()
+    end)
+  end
+  if bus then
+    pcall(function()
+      bus:close()
+    end)
+  end
+
+  if not ok then
+    print("[unihiker_motor] ERROR: " .. tostring(err))
+    error(err)
+  end
+end
+
+run()


### PR DESCRIPTION
## Description
The skill related to the motor drive function of the UNIHIKER Expansion Board for the UNIHIKER K10 extension board. Users can make the motors on the Expansion Board rotate by using natural language.

<img src="https://github.com/user-attachments/assets/9d349f18-0dd0-4890-ba45-716ba3c11e7f" width=800px>


## Related


## Testing

Use [Unihiker Expansion Board (DFR1216)](https://www.dfrobot.com/product-2974.html) and power it with 18650 Lipo battery, connect it with any 6V motor or below. (I use normal N20 motor).
And tell the ESP CLAW to drive the motor M1, M2, M3 or M4 in the speed of a value in between 0~255.

## Checklist

Before submitting a Pull Request, please ensure the following:

- [√ ] 🚨 This PR does not introduce breaking changes.
- [√ ] All CI checks (GH Actions) pass.
- [√ ] Documentation is updated as needed.
- [√ ] Tests are updated or added as necessary.
- [√ ] Code is well-commented, especially in complex areas.
- [√ ] Git history is clean — commits are squashed to the minimum necessary.
