### PR TITLE
Feat: Add servo drive, WS2812, battery, IR data function of UNIHIKER …

### DIFF
--- a/skills/unihiker_expansion_WS2812/SKILL.md
+++ b/skills/unihiker_expansion_WS2812/SKILL.md
@@ -7,7 +7,6 @@
     {
       "category": ["sensor"],
       "tags": ["ws2812", "rgb", "led", "unihiker", "dfrobot", "expansion board", "i2c"],
-      "peripherals": ["led"],
       "cap_groups": ["cap_lua"],
       "manage_mode": "web"
     }

--- a/skills/unihiker_expansion_WS2812/SKILL.md
+++ b/skills/unihiker_expansion_WS2812/SKILL.md
@@ -1,0 +1,116 @@
+---
+{
+  "name": "unihiker_expansion_WS2812",
+  "description": "Set WS2812 RGB LEDs on the DFRobot UNIHIKER Expansion board over I2C. This skill controls expansion-board LEDs only, not the UNIHIKER mainboard RGB.",
+  "author": "YeezB",
+  "metadata":
+    {
+      "category": ["sensor"],
+      "tags": ["ws2812", "rgb", "led", "unihiker", "dfrobot", "expansion board", "i2c"],
+      "peripherals": ["led"],
+      "cap_groups": ["cap_lua"],
+      "manage_mode": "web"
+    }
+}
+---
+
+# UNIHIKER Expansion WS2812
+
+Use this skill when the user asks to set WS2812 or RGB LEDs on a DFRobot UNIHIKER Expansion board (SKU: DFR1216). Chinese name is 行空板扩展板.
+
+This skill controls the two WS2812 LEDs on the UNIHIKER Expansion board only.
+Do not use this skill for the UNIHIKER mainboard built-in RGB LED.
+
+Run exactly one bundled Lua script with `lua_run_script`.
+
+If script execution returns an error, report that error directly to the user.
+Do not retry with changed arguments in the same turn unless the user explicitly asks.
+
+## Script Args Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "bright": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 255
+    },
+    "rgb0": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 16777215
+    },
+    "rgb1": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 16777215
+    },
+    "color": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 16777215
+    },
+    "i2c_port": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "sda": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 63
+    },
+    "scl": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 63
+    },
+    "i2c_freq_hz": {
+      "type": "integer",
+      "minimum": 10000,
+      "maximum": 1000000
+    },
+    "addr": {
+      "type": "integer",
+      "minimum": 8,
+      "maximum": 119
+    }
+  }
+}
+```
+
+## Tool Call Inputs
+
+Set both expansion-board WS2812 LEDs to magenta:
+
+```json
+{"path":"{CUR_SKILL_DIR}/scripts/set_ws2812.lua","args":{"bright":30,"color":16711935}}
+```
+
+Set RGB0 to red and RGB1 to blue:
+
+```json
+{"path":"{CUR_SKILL_DIR}/scripts/set_ws2812.lua","args":{"bright":10,"rgb0":16711680,"rgb1":255}}
+```
+
+Set RGB0 yellow and RGB1 magenta at higher brightness:
+
+```json
+{"path":"{CUR_SKILL_DIR}/scripts/set_ws2812.lua","args":{"bright":100,"rgb0":16776960,"rgb1":16711935}}
+```
+
+Turn off both expansion-board WS2812 LEDs:
+
+```json
+{"path":"{CUR_SKILL_DIR}/scripts/set_ws2812.lua","args":{"bright":0,"color":0}}
+```
+
+## Recommended Flow
+
+1. Confirm the target is the UNIHIKER Expansion board WS2812 LEDs, not the UNIHIKER mainboard RGB LED.
+2. Use default I2C settings unless the user explicitly provides custom wiring.
+3. If the user gives one color for RGB灯, use `color` to set both LEDs.
+4. Otherwise set `rgb0` and `rgb1` independently.
+5. Run `{CUR_SKILL_DIR}/scripts/set_ws2812.lua` and report result or error directly.

--- a/skills/unihiker_expansion_WS2812/SKILL.md
+++ b/skills/unihiker_expansion_WS2812/SKILL.md
@@ -6,7 +6,8 @@
   "metadata":
     {
       "category": ["sensor"],
-      "tags": ["ws2812", "rgb", "led", "unihiker", "dfrobot", "expansion board", "i2c"],
+      "tags": ["rgb", "unihiker", "dfrobot", "expansion board", "i2c"],
+      "peripherals": ["ws2812", "led"],
       "cap_groups": ["cap_lua"],
       "manage_mode": "web"
     }

--- a/skills/unihiker_expansion_WS2812/scripts/set_ws2812.lua
+++ b/skills/unihiker_expansion_WS2812/scripts/set_ws2812.lua
@@ -1,0 +1,120 @@
+local i2c = require("i2c")
+
+local DEFAULT_I2C_PORT = 0
+local DEFAULT_SDA = 47
+local DEFAULT_SCL = 48
+local DEFAULT_I2C_FREQ_HZ = 400000
+local DEFAULT_ADDR = 0x33
+
+local REG_WS2812 = 0x90
+local DATA_ENABLE = 0x01
+
+local DEFAULT_BRIGHT = 10
+local DEFAULT_RGB0 = 0xFF0000
+local DEFAULT_RGB1 = 0x0000FF
+
+local function read_arg(name, default)
+  if type(args) == "table" and args[name] ~= nil then
+    return args[name]
+  end
+  return default
+end
+
+local function parse_int_arg(name, default, min_value, max_value)
+  local value = read_arg(name, default)
+  if type(value) ~= "number" or value % 1 ~= 0 then
+    error(name .. " must be an integer")
+  end
+  if min_value ~= nil and value < min_value then
+    error(string.format("%s must be >= %d", name, min_value))
+  end
+  if max_value ~= nil and value > max_value then
+    error(string.format("%s must be <= %d", name, max_value))
+  end
+  return value
+end
+
+local function cleanup(dev, bus)
+  if dev then
+    pcall(function()
+      dev:close()
+    end)
+  end
+  if bus then
+    pcall(function()
+      bus:close()
+    end)
+  end
+end
+
+local function rgb_to_bytes(rgb)
+  local r = math.floor(rgb / 0x10000) % 0x100
+  local g = math.floor(rgb / 0x100) % 0x100
+  local b = rgb % 0x100
+  return r, g, b
+end
+
+local function format_rgb(rgb)
+  return string.format("0x%06X", rgb)
+end
+
+local function run()
+  local i2c_port = parse_int_arg("i2c_port", DEFAULT_I2C_PORT, 0, 1)
+  local sda = parse_int_arg("sda", DEFAULT_SDA, 0, 63)
+  local scl = parse_int_arg("scl", DEFAULT_SCL, 0, 63)
+  local i2c_freq_hz = parse_int_arg("i2c_freq_hz", DEFAULT_I2C_FREQ_HZ, 10000, 1000000)
+  local addr = parse_int_arg("addr", DEFAULT_ADDR, 0x08, 0x77)
+
+  local bright = parse_int_arg("bright", DEFAULT_BRIGHT, 0, 255)
+  local color = read_arg("color", nil)
+  local rgb0
+  local rgb1
+
+  if color ~= nil then
+    if type(color) ~= "number" or color % 1 ~= 0 then
+      error("color must be an integer")
+    end
+    if color < 0 or color > 0xFFFFFF then
+      error("color must be in range 0-16777215")
+    end
+    rgb0 = color
+    rgb1 = color
+  else
+    rgb0 = parse_int_arg("rgb0", DEFAULT_RGB0, 0, 0xFFFFFF)
+    rgb1 = parse_int_arg("rgb1", DEFAULT_RGB1, 0, 0xFFFFFF)
+  end
+
+  local r0, g0, b0 = rgb_to_bytes(rgb0)
+  local r1, g1, b1 = rgb_to_bytes(rgb1)
+
+  local bus = nil
+  local dev = nil
+
+  local ok, err = xpcall(function()
+    bus = i2c.new(i2c_port, sda, scl, i2c_freq_hz)
+    dev = bus:device(addr)
+
+    dev:write({DATA_ENABLE, bright, r0, g0, b0, r1, g1, b1}, REG_WS2812)
+
+    print(string.format(
+      "[unihiker_expansion_WS2812] ok bright=%d rgb0=%s rgb1=%s addr=0x%02X port=%d sda=%d scl=%d freq=%d",
+      bright,
+      format_rgb(rgb0),
+      format_rgb(rgb1),
+      addr,
+      i2c_port,
+      sda,
+      scl,
+      i2c_freq_hz
+    ))
+  end, debug.traceback)
+
+  cleanup(dev, bus)
+
+  if not ok then
+    print("[unihiker_expansion_WS2812] ERROR: " .. tostring(err))
+    error(err)
+  end
+end
+
+run()

--- a/skills/unihiker_expansion_battery/SKILL.md
+++ b/skills/unihiker_expansion_battery/SKILL.md
@@ -1,0 +1,90 @@
+---
+{
+  "name": "unihiker_expansion_battery",
+  "description": "Read battery percentage from a DFRobot UNIHIKER Expansion board over I2C. Requires the expansion board to be connected.",
+  "author": "YeezB",
+  "metadata":
+    {
+      "category": ["sensor"],
+      "tags": ["battery", "unihiker", "dfrobot", "expansion board", "i2c"],
+      "peripherals": ["battery"],
+      "cap_groups": ["cap_lua"],
+      "manage_mode": "web"
+    }
+}
+---
+
+# UNIHIKER Expansion Battery
+
+Use this skill when the user asks to read battery percentage from a DFRobot UNIHIKER Expansion board (SKU: DFR1216). Chinese name is 行空板扩展板.
+
+Run exactly one bundled Lua script with `lua_run_script`.
+
+If script execution returns an error, report that error directly to the user.
+Do not retry with changed arguments in the same turn unless the user explicitly asks.
+
+## Script Args Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "i2c_port": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "sda": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 63
+    },
+    "scl": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 63
+    },
+    "i2c_freq_hz": {
+      "type": "integer",
+      "minimum": 10000,
+      "maximum": 1000000
+    },
+    "addr": {
+      "type": "integer",
+      "minimum": 8,
+      "maximum": 119
+    },
+    "retry_count": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 20
+    },
+    "retry_delay_ms": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 1000
+    }
+  }
+}
+```
+
+## Tool Call Inputs
+
+Read battery with default wiring:
+
+```json
+{"path":"{CUR_SKILL_DIR}/scripts/get_battery.lua","args":{}}
+```
+
+Read battery with custom I2C pins:
+
+```json
+{"path":"{CUR_SKILL_DIR}/scripts/get_battery.lua","args":{"i2c_port":0,"sda":47,"scl":48,"i2c_freq_hz":400000,"addr":51}}
+```
+
+## Recommended Flow
+
+1. Confirm the expansion board is connected to the expected I2C bus.
+2. Use default I2C settings unless the user explicitly provides custom wiring.
+3. Run `{CUR_SKILL_DIR}/scripts/get_battery.lua`.
+4. Report the script output directly to the user, including any error.

--- a/skills/unihiker_expansion_battery/SKILL.md
+++ b/skills/unihiker_expansion_battery/SKILL.md
@@ -6,7 +6,8 @@
   "metadata":
     {
       "category": ["sensor"],
-      "tags": ["battery", "unihiker", "dfrobot", "expansion board", "i2c"],
+      "tags": ["unihiker", "dfrobot", "expansion board", "i2c"],
+      "peripherals": ["battery"],
       "cap_groups": ["cap_lua"],
       "manage_mode": "web"
     }

--- a/skills/unihiker_expansion_battery/SKILL.md
+++ b/skills/unihiker_expansion_battery/SKILL.md
@@ -7,7 +7,6 @@
     {
       "category": ["sensor"],
       "tags": ["battery", "unihiker", "dfrobot", "expansion board", "i2c"],
-      "peripherals": ["battery"],
       "cap_groups": ["cap_lua"],
       "manage_mode": "web"
     }

--- a/skills/unihiker_expansion_battery/scripts/get_battery.lua
+++ b/skills/unihiker_expansion_battery/scripts/get_battery.lua
@@ -1,0 +1,97 @@
+local i2c = require("i2c")
+local delay = require("delay")
+
+local DEFAULT_I2C_PORT = 0
+local DEFAULT_SDA = 47
+local DEFAULT_SCL = 48
+local DEFAULT_I2C_FREQ_HZ = 400000
+local DEFAULT_ADDR = 0x33
+
+local REG_BATTERY = 0x87
+local DEFAULT_RETRY_COUNT = 10
+local DEFAULT_RETRY_DELAY_MS = 20
+
+local function read_arg(name, default)
+  if type(args) == "table" and args[name] ~= nil then
+    return args[name]
+  end
+  return default
+end
+
+local function parse_int_arg(name, default, min_value, max_value)
+  local value = read_arg(name, default)
+  if type(value) ~= "number" or value % 1 ~= 0 then
+    error(name .. " must be an integer")
+  end
+  if min_value ~= nil and value < min_value then
+    error(string.format("%s must be >= %d", name, min_value))
+  end
+  if max_value ~= nil and value > max_value then
+    error(string.format("%s must be <= %d", name, max_value))
+  end
+  return value
+end
+
+local function cleanup(dev, bus)
+  if dev then
+    pcall(function()
+      dev:close()
+    end)
+  end
+  if bus then
+    pcall(function()
+      bus:close()
+    end)
+  end
+end
+
+local function run()
+  local i2c_port = parse_int_arg("i2c_port", DEFAULT_I2C_PORT, 0, 1)
+  local sda = parse_int_arg("sda", DEFAULT_SDA, 0, 63)
+  local scl = parse_int_arg("scl", DEFAULT_SCL, 0, 63)
+  local i2c_freq_hz = parse_int_arg("i2c_freq_hz", DEFAULT_I2C_FREQ_HZ, 10000, 1000000)
+  local addr = parse_int_arg("addr", DEFAULT_ADDR, 0x08, 0x77)
+  local retry_count = parse_int_arg("retry_count", DEFAULT_RETRY_COUNT, 1, 20)
+  local retry_delay_ms = parse_int_arg("retry_delay_ms", DEFAULT_RETRY_DELAY_MS, 0, 1000)
+
+  local bus = nil
+  local dev = nil
+
+  local ok, err = xpcall(function()
+    bus = i2c.new(i2c_port, sda, scl, i2c_freq_hz)
+    dev = bus:device(addr)
+
+    for attempt = 1, retry_count do
+      local value = dev:read_byte(REG_BATTERY)
+
+      if value >= 0 and value <= 100 then
+        print(string.format(
+          "[unihiker_expansion_battery] battery=%d%% addr=0x%02X port=%d sda=%d scl=%d freq=%d attempt=%d",
+          value,
+          addr,
+          i2c_port,
+          sda,
+          scl,
+          i2c_freq_hz,
+          attempt
+        ))
+        return
+      end
+
+      if attempt < retry_count and retry_delay_ms > 0 then
+        delay.delay_ms(retry_delay_ms)
+      end
+    end
+
+    error("battery read failed or out of range after retries")
+  end, debug.traceback)
+
+  cleanup(dev, bus)
+
+  if not ok then
+    print("[unihiker_expansion_battery] ERROR: " .. tostring(err))
+    error(err)
+  end
+end
+
+run()

--- a/skills/unihiker_expansion_ir/SKILL.md
+++ b/skills/unihiker_expansion_ir/SKILL.md
@@ -7,7 +7,6 @@
     {
       "category": ["sensor"],
       "tags": ["ir", "infrared", "unihiker", "dfrobot", "expansion board", "i2c"],
-      "peripherals": ["ir"],
       "cap_groups": ["cap_lua"],
       "manage_mode": "web"
     }

--- a/skills/unihiker_expansion_ir/SKILL.md
+++ b/skills/unihiker_expansion_ir/SKILL.md
@@ -1,0 +1,106 @@
+---
+{
+  "name": "unihiker_expansion_ir",
+  "description": "Send and receive IR data on a DFRobot UNIHIKER Expansion board over I2C. Requires the expansion board to be connected.",
+  "author": "YeezB",
+  "metadata":
+    {
+      "category": ["sensor"],
+      "tags": ["ir", "infrared", "unihiker", "dfrobot", "expansion board", "i2c"],
+      "peripherals": ["ir"],
+      "cap_groups": ["cap_lua"],
+      "manage_mode": "web"
+    }
+}
+---
+
+# UNIHIKER Expansion IR
+
+Use this skill when the user asks to send IR code, read IR code, or self-send and self-receive IR data on a DFRobot UNIHIKER Expansion board (SKU: DFR1216). Chinese name is 行空板扩展板.
+
+Run exactly one bundled Lua script with `lua_run_script`.
+
+If script execution returns an error, report that error directly to the user.
+Do not retry with changed arguments in the same turn unless the user explicitly asks.
+
+## Script Args Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "mode": {
+      "type": "string",
+      "enum": ["send", "get", "send_get"]
+    },
+    "data": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 4294967295
+    },
+    "timeout_ms": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 60000
+    },
+    "poll_interval_ms": {
+      "type": "integer",
+      "minimum": 10,
+      "maximum": 5000
+    },
+    "i2c_port": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "sda": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 63
+    },
+    "scl": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 63
+    },
+    "i2c_freq_hz": {
+      "type": "integer",
+      "minimum": 10000,
+      "maximum": 1000000
+    },
+    "addr": {
+      "type": "integer",
+      "minimum": 8,
+      "maximum": 119
+    }
+  }
+}
+```
+
+## Tool Call Inputs
+
+Send one IR code only:
+
+```json
+{"path":"{CUR_SKILL_DIR}/scripts/ir_send_get.lua","args":{"mode":"send","data":305419896}}
+```
+
+Read one IR code only:
+
+```json
+{"path":"{CUR_SKILL_DIR}/scripts/ir_send_get.lua","args":{"mode":"get","timeout_ms":2000,"poll_interval_ms":100}}
+```
+
+Self-send and self-receive in one call:
+
+```json
+{"path":"{CUR_SKILL_DIR}/scripts/ir_send_get.lua","args":{"mode":"send_get","data":305419896,"timeout_ms":2000,"poll_interval_ms":100}}
+```
+
+## Recommended Flow
+
+1. Confirm the expansion board is connected to the expected I2C bus.
+2. Use default I2C settings unless the user explicitly provides custom wiring.
+3. Use `mode = "send_get"` when user asks for self-send/self-receive in one operation.
+4. Run `{CUR_SKILL_DIR}/scripts/ir_send_get.lua` with resolved args.
+5. Report script output directly to the user, including any error.

--- a/skills/unihiker_expansion_ir/SKILL.md
+++ b/skills/unihiker_expansion_ir/SKILL.md
@@ -6,7 +6,8 @@
   "metadata":
     {
       "category": ["sensor"],
-      "tags": ["ir", "infrared", "unihiker", "dfrobot", "expansion board", "i2c"],
+      "tags": ["infrared", "unihiker", "dfrobot", "expansion board", "i2c"],
+      "peripherals": ["ir"],
       "cap_groups": ["cap_lua"],
       "manage_mode": "web"
     }

--- a/skills/unihiker_expansion_ir/scripts/ir_send_get.lua
+++ b/skills/unihiker_expansion_ir/scripts/ir_send_get.lua
@@ -1,0 +1,166 @@
+local i2c = require("i2c")
+local delay = require("delay")
+
+local DEFAULT_I2C_PORT = 0
+local DEFAULT_SDA = 47
+local DEFAULT_SCL = 48
+local DEFAULT_I2C_FREQ_HZ = 400000
+local DEFAULT_ADDR = 0x33
+
+local REG_IR_SEND = 0x24
+local REG_IR_RECV = 0x88
+local DATA_ENABLE = 0x01
+local DATA_DISABLE = 0x00
+
+local DEFAULT_MODE = "send_get"
+local DEFAULT_DATA = 0x12345678
+local DEFAULT_TIMEOUT_MS = 2000
+local DEFAULT_POLL_INTERVAL_MS = 100
+
+local function read_arg(name, default)
+  if type(args) == "table" and args[name] ~= nil then
+    return args[name]
+  end
+  return default
+end
+
+local function parse_int_arg(name, default, min_value, max_value)
+  local value = read_arg(name, default)
+  if type(value) ~= "number" or value % 1 ~= 0 then
+    error(name .. " must be an integer")
+  end
+  if min_value ~= nil and value < min_value then
+    error(string.format("%s must be >= %d", name, min_value))
+  end
+  if max_value ~= nil and value > max_value then
+    error(string.format("%s must be <= %d", name, max_value))
+  end
+  return value
+end
+
+local function parse_enum_arg(name, default, allowed_values)
+  local value = read_arg(name, default)
+  if type(value) ~= "string" then
+    error(name .. " must be a string")
+  end
+  for i = 1, #allowed_values do
+    if value == allowed_values[i] then
+      return value
+    end
+  end
+  error(name .. " must be one of: " .. table.concat(allowed_values, ", "))
+end
+
+local function cleanup(dev, bus)
+  if dev then
+    pcall(function()
+      dev:close()
+    end)
+  end
+  if bus then
+    pcall(function()
+      bus:close()
+    end)
+  end
+end
+
+local function format_hex_u32(value)
+  return string.format("0x%08X", value)
+end
+
+local function send_ir(dev, value)
+  local b1 = math.floor(value / 0x1000000) % 0x100
+  local b2 = math.floor(value / 0x10000) % 0x100
+  local b3 = math.floor(value / 0x100) % 0x100
+  local b4 = value % 0x100
+
+  dev:write({DATA_ENABLE, b1, b2, b3, b4}, REG_IR_SEND)
+end
+
+local function read_ir_once(dev)
+  local raw = dev:read(5, REG_IR_RECV)
+  local flag = string.byte(raw, 1)
+  if flag == DATA_DISABLE then
+    return nil
+  end
+  local b1 = string.byte(raw, 2)
+  local b2 = string.byte(raw, 3)
+  local b3 = string.byte(raw, 4)
+  local b4 = string.byte(raw, 5)
+  return (((b1 * 256 + b2) * 256 + b3) * 256 + b4)
+end
+
+local function poll_ir(dev, timeout_ms, poll_interval_ms)
+  local elapsed = 0
+  while elapsed <= timeout_ms do
+    local value = read_ir_once(dev)
+    if value ~= nil then
+      return value, elapsed
+    end
+    if elapsed == timeout_ms then
+      break
+    end
+    local wait_ms = poll_interval_ms
+    if elapsed + wait_ms > timeout_ms then
+      wait_ms = timeout_ms - elapsed
+    end
+    if wait_ms > 0 then
+      delay.delay_ms(wait_ms)
+    end
+    elapsed = elapsed + wait_ms
+  end
+  return nil, elapsed
+end
+
+local function run()
+  local mode = parse_enum_arg("mode", DEFAULT_MODE, {"send", "get", "send_get"})
+  local data = parse_int_arg("data", DEFAULT_DATA, 0, 0xFFFFFFFF)
+  local timeout_ms = parse_int_arg("timeout_ms", DEFAULT_TIMEOUT_MS, 0, 60000)
+  local poll_interval_ms = parse_int_arg("poll_interval_ms", DEFAULT_POLL_INTERVAL_MS, 10, 5000)
+  local i2c_port = parse_int_arg("i2c_port", DEFAULT_I2C_PORT, 0, 1)
+  local sda = parse_int_arg("sda", DEFAULT_SDA, 0, 63)
+  local scl = parse_int_arg("scl", DEFAULT_SCL, 0, 63)
+  local i2c_freq_hz = parse_int_arg("i2c_freq_hz", DEFAULT_I2C_FREQ_HZ, 10000, 1000000)
+  local addr = parse_int_arg("addr", DEFAULT_ADDR, 0x08, 0x77)
+
+  local bus = nil
+  local dev = nil
+
+  local ok, err = xpcall(function()
+    bus = i2c.new(i2c_port, sda, scl, i2c_freq_hz)
+    dev = bus:device(addr)
+
+    if mode == "send" or mode == "send_get" then
+      send_ir(dev, data)
+      print(string.format("[unihiker_expansion_ir] sent=%s", format_hex_u32(data)))
+    end
+
+    if mode == "get" or mode == "send_get" then
+      local value, elapsed = poll_ir(dev, timeout_ms, poll_interval_ms)
+      if value ~= nil then
+        print(string.format("[unihiker_expansion_ir] received=%s elapsed_ms=%d", format_hex_u32(value), elapsed))
+      else
+        print(string.format("[unihiker_expansion_ir] no data within timeout_ms=%d", timeout_ms))
+      end
+    end
+
+    print(string.format(
+      "[unihiker_expansion_ir] ok mode=%s addr=0x%02X port=%d sda=%d scl=%d freq=%d",
+      mode,
+      addr,
+      i2c_port,
+      sda,
+      scl,
+      i2c_freq_hz
+    ))
+  end, debug.traceback)
+
+  cleanup(dev, bus)
+
+  if not ok then
+    print("[unihiker_expansion_ir] ERROR: " .. tostring(err))
+    error(err)
+  end
+end
+
+run()

--- a/skills/unihiker_expansion_servo_control/SKILL.md
+++ b/skills/unihiker_expansion_servo_control/SKILL.md
@@ -1,0 +1,121 @@
+---
+{
+  "name": "unihiker_expansion_servo_control",
+  "description": "Control 180° or 360° servos on a DFRobot UNIHIKER Expansion board over I2C. Requires the expansion board to be connected.",
+  "author": "YeezB",
+  "metadata":
+    {
+      "category": ["sensor"],
+      "tags": ["servo", "unihiker", "dfrobot", "expansion board", "i2c"],
+      "peripherals": ["servo"],
+      "cap_groups": ["cap_lua"],
+      "manage_mode": "web"
+    }
+}
+---
+
+# UNIHIKER Expansion Servo Control
+
+Use this skill when the user asks to set the angle of a 180° servo or set the direction/speed of a 360° servo on a DFRobot UNIHIKER Expansion board (SKU: DFR1216). Chinese name is 行空板扩展板.
+
+Run exactly one bundled Lua script with `lua_run_script`.
+
+If script execution returns an error, report that error directly to the user.
+Do not retry with changed arguments in the same turn unless the user explicitly asks.
+
+## Script Args Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "mode": {
+      "type": "string",
+      "enum": ["angle", "servo360"]
+    },
+    "servo": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 5
+    },
+    "angle": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 180
+    },
+    "direction": {
+      "type": "string",
+      "enum": ["forward", "backward", "stop"]
+    },
+    "speed": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 100
+    },
+    "duration_ms": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "i2c_port": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "sda": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 63
+    },
+    "scl": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 63
+    },
+    "i2c_freq_hz": {
+      "type": "integer",
+      "minimum": 10000,
+      "maximum": 1000000
+    },
+    "addr": {
+      "type": "integer",
+      "minimum": 8,
+      "maximum": 119
+    }
+  },
+  "required": ["mode", "servo"]
+}
+```
+
+## Tool Call Inputs
+
+Set a 180° servo to 90°:
+
+```json
+{"path":"{CUR_SKILL_DIR}/scripts/set_servo.lua","args":{"mode":"angle","servo":0,"angle":90}}
+```
+
+Set a 360° servo to forward at speed 50:
+
+```json
+{"path":"{CUR_SKILL_DIR}/scripts/set_servo.lua","args":{"mode":"servo360","servo":1,"direction":"forward","speed":50}}
+```
+
+Stop a 360° servo:
+
+```json
+{"path":"{CUR_SKILL_DIR}/scripts/set_servo.lua","args":{"mode":"servo360","servo":1,"direction":"stop","speed":0}}
+```
+
+Run a 360° servo for 2 seconds and then stop:
+
+```json
+{"path":"{CUR_SKILL_DIR}/scripts/set_servo.lua","args":{"mode":"servo360","servo":2,"direction":"backward","speed":30,"duration_ms":2000}}
+```
+
+## Recommended Flow
+
+1. Confirm the expansion board is connected to the expected I2C bus.
+2. Use the default UNIHIKER expansion board I2C settings unless the user explicitly provides custom wiring or address values.
+3. Choose `mode = "angle"` for 180° servos and `mode = "servo360"` for 360° servos.
+4. Run `{CUR_SKILL_DIR}/scripts/set_servo.lua` with the resolved servo number and motion parameters.
+5. Report the script output directly to the user, including any error.

--- a/skills/unihiker_expansion_servo_control/SKILL.md
+++ b/skills/unihiker_expansion_servo_control/SKILL.md
@@ -7,7 +7,6 @@
     {
       "category": ["sensor"],
       "tags": ["servo", "unihiker", "dfrobot", "expansion board", "i2c"],
-      "peripherals": ["servo"],
       "cap_groups": ["cap_lua"],
       "manage_mode": "web"
     }

--- a/skills/unihiker_expansion_servo_control/SKILL.md
+++ b/skills/unihiker_expansion_servo_control/SKILL.md
@@ -6,7 +6,8 @@
   "metadata":
     {
       "category": ["sensor"],
-      "tags": ["servo", "unihiker", "dfrobot", "expansion board", "i2c"],
+      "tags": ["unihiker", "dfrobot", "expansion board", "i2c"],
+      "peripherals": ["servo"],
       "cap_groups": ["cap_lua"],
       "manage_mode": "web"
     }

--- a/skills/unihiker_expansion_servo_control/scripts/set_servo.lua
+++ b/skills/unihiker_expansion_servo_control/scripts/set_servo.lua
@@ -1,0 +1,187 @@
+local i2c = require("i2c")
+local delay = require("delay")
+
+local DEFAULT_I2C_PORT = 0
+local DEFAULT_SDA = 47
+local DEFAULT_SCL = 48
+local DEFAULT_I2C_FREQ_HZ = 400000
+local DEFAULT_ADDR = 0x33
+
+local REG_SERVO0_DUTY_H = 0x18
+local SERVO_COUNT = 6
+
+local function read_arg(name, default)
+  if type(args) == "table" and args[name] ~= nil then
+    return args[name]
+  end
+  return default
+end
+
+local function parse_int_arg(name, default, min_value, max_value)
+  local value = read_arg(name, default)
+  if type(value) ~= "number" or value % 1 ~= 0 then
+    error(name .. " must be an integer")
+  end
+  if min_value ~= nil and value < min_value then
+    error(string.format("%s must be >= %d", name, min_value))
+  end
+  if max_value ~= nil and value > max_value then
+    error(string.format("%s must be <= %d", name, max_value))
+  end
+  return value
+end
+
+local function parse_string_arg(name, default)
+  local value = read_arg(name, default)
+  if type(value) ~= "string" then
+    error(name .. " must be a string")
+  end
+  return value
+end
+
+local function parse_enum_arg(name, default, allowed_values)
+  local value = parse_string_arg(name, default)
+  for i = 1, #allowed_values do
+    if value == allowed_values[i] then
+      return value
+    end
+  end
+  error(name .. " must be one of: " .. table.concat(allowed_values, ", "))
+end
+
+local function to_u16_bytes(value)
+  return {
+    math.floor(value / 256) % 256,
+    value % 256,
+  }
+end
+
+local function write_u16(dev, reg, value)
+  dev:write(to_u16_bytes(value), reg)
+end
+
+local function servo_reg(servo)
+  return REG_SERVO0_DUTY_H + servo * 2
+end
+
+local function servo_angle_to_period(angle)
+  if angle > 180 then
+    angle = 180
+  end
+  if angle < 0 then
+    angle = 0
+  end
+  return math.floor(500 + angle * 11)
+end
+
+local function servo360_to_period(direction, speed)
+  if speed > 100 then
+    speed = 100
+  end
+  if speed < 0 then
+    speed = 0
+  end
+
+  if direction == "backward" then
+    return math.floor(1550 + speed * 4.5)
+  elseif direction == "forward" then
+    return math.floor(1450 - speed * 4.5)
+  elseif direction == "stop" then
+    return 1500
+  end
+
+  error("direction must be forward, backward, or stop")
+end
+
+local function cleanup(dev, bus)
+  if dev then
+    pcall(function()
+      dev:close()
+    end)
+  end
+  if bus then
+    pcall(function()
+      bus:close()
+    end)
+  end
+end
+
+local function run()
+  local mode = parse_enum_arg("mode", "angle", {"angle", "servo360"})
+  local servo = parse_int_arg("servo", nil, 0, SERVO_COUNT - 1)
+  local i2c_port = parse_int_arg("i2c_port", DEFAULT_I2C_PORT, 0, 1)
+  local sda = parse_int_arg("sda", DEFAULT_SDA, 0, 63)
+  local scl = parse_int_arg("scl", DEFAULT_SCL, 0, 63)
+  local i2c_freq_hz = parse_int_arg("i2c_freq_hz", DEFAULT_I2C_FREQ_HZ, 10000, 1000000)
+  local addr = parse_int_arg("addr", DEFAULT_ADDR, 0x08, 0x77)
+
+  local bus = nil
+  local dev = nil
+
+  local ok, err = xpcall(function()
+    if mode == "angle" then
+      local angle = parse_int_arg("angle", nil, 0, 180)
+      local period = servo_angle_to_period(angle)
+
+      bus = i2c.new(i2c_port, sda, scl, i2c_freq_hz)
+      dev = bus:device(addr)
+      write_u16(dev, servo_reg(servo), period)
+
+      print(string.format(
+        "[unihiker_expansion_servo_control] ok mode=angle servo=%d angle=%d period=%d addr=0x%02X port=%d sda=%d scl=%d freq=%d",
+        servo,
+        angle,
+        period,
+        addr,
+        i2c_port,
+        sda,
+        scl,
+        i2c_freq_hz
+      ))
+
+      local duration_ms = parse_int_arg("duration_ms", 0, 0, 3600000)
+      if duration_ms > 0 then
+        delay.delay_ms(duration_ms)
+        print(string.format("[unihiker_expansion_servo_control] settled after %d ms", duration_ms))
+      end
+      return
+    end
+
+    local direction = parse_enum_arg("direction", "stop", {"forward", "backward", "stop"})
+    local speed = parse_int_arg("speed", 0, 0, 100)
+    local duration_ms = parse_int_arg("duration_ms", 0, 0, 3600000)
+    local period = servo360_to_period(direction, speed)
+
+    bus = i2c.new(i2c_port, sda, scl, i2c_freq_hz)
+    dev = bus:device(addr)
+    write_u16(dev, servo_reg(servo), period)
+
+    print(string.format(
+      "[unihiker_expansion_servo_control] ok mode=servo360 servo=%d direction=%s speed=%d period=%d addr=0x%02X port=%d sda=%d scl=%d freq=%d",
+      servo,
+      direction,
+      speed,
+      period,
+      addr,
+      i2c_port,
+      sda,
+      scl,
+      i2c_freq_hz
+    ))
+
+    if duration_ms > 0 and direction ~= "stop" then
+      delay.delay_ms(duration_ms)
+      write_u16(dev, servo_reg(servo), 1500)
+      print(string.format("[unihiker_expansion_servo_control] auto-stopped after %d ms", duration_ms))
+    end
+  end, debug.traceback)
+
+  cleanup(dev, bus)
+
+  if not ok then
+    print("[unihiker_expansion_servo_control] ERROR: " .. tostring(err))
+    error(err)
+  end
+end
+
+run()

--- a/src/config/allowlist.ts
+++ b/src/config/allowlist.ts
@@ -19,6 +19,10 @@ export const ALLOWED_PERIPHERALS = [
   'display',
   'button',
   'gpio',
+  'battery',
+  'ir',
+  'servo',
+  'ws2812',
 ] as const
 
 export type Peripheral = (typeof ALLOWED_PERIPHERALS)[number]


### PR DESCRIPTION
…Expansion board

## Description

The skill related to the servo drive, WS2812, battery, IR data send&receive function of the UNIHIKER Expansion Board for the UNIHIKER K10. Users can make the servos on the Expansion Board rotate, set on the WS2812, read the remain capacity of battery, and send/receive IR data by using natural language.

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

### Servo Drive
<img src="https://github.com/user-attachments/assets/7e489e4e-53ac-4ae7-ac5d-d414f91648fe" width=500px>

### WS2812
<img src="https://github.com/user-attachments/assets/6f40896c-91f7-4026-b95b-3885b7a87dbf" width=500px>

### Battery
<img src="https://github.com/user-attachments/assets/69976fb6-4723-4075-b969-6264312a6245" width=500px>

### IR data
<img src="https://github.com/user-attachments/assets/c576b1e5-7177-4cf3-bd16-ef10173f1e65" width=500px>



## Testing

Use [Unihiker Expansion Board (DFR1216)](https://www.dfrobot.com/product-2974.html) and power it with 18650 Lipo battery, connect it with any servor.
And tell the ESP CLAW to drive the servo in the speed of a value in between 0~255.
Ask ESP CLAW about the remain capacity of battery.
Ask the UNIHIKER Expansion Board to send/receive IR data.
Ask the UNIHIKER Expansion Board to set the on board RGB light in xxx

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ √ ] 🚨 This PR does not introduce breaking changes.
- [ √ ] All CI checks (GH Actions) pass.
- [ √ ] Documentation is updated as needed.
- [ √ ] Tests are updated or added as necessary.
- [ √ ] Code is well-commented, especially in complex areas.
- [ √ ] Git history is clean — commits are squashed to the minimum necessary.
