### PR TITLE
feat: add servo dog lua skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ src/generated/*
 !src/generated/.gitkeep
 
 skills/**/_metadata.json
+
+Agent.md

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -2,5 +2,5 @@
   "$schema": "./node_modules/oxfmt/configuration_schema.json",
   "semi": false,
   "singleQuote": true,
-  "ignorePatterns": [".vscode/**/*.json", "skills/**/*.md"]
+  "ignorePatterns": [".vscode/**/*.json", "skills/**/*"]
 }

--- a/skills/servo_dog/SKILL.md
+++ b/skills/servo_dog/SKILL.md
@@ -1,0 +1,195 @@
+---
+{
+  "name": "servo_dog",
+  "description": "Control a four-servo robotic dog named Servo Dog through Lua PWM actions, command calls, and a Lua HTTP Server web control panel.",
+  "metadata": {
+    "cap_groups": [
+      "cap_lua"
+    ],
+    "manage_mode": "readonly",
+    "category": ["game"],
+    "tags": ["servo", "ai"]
+  }
+}
+---
+
+# Servo Dog
+
+Use this skill when the user asks to control a four-servo robotic dog, start the Servo Dog web control panel, calibrate dog leg servo offsets, or run dog actions such as forward, backward, turn, bow, shake hand, jump, or retract legs.
+
+This skill controls four servos directly from Lua with `mcpwm`. Default GPIOs are:
+
+- `fl_gpio`: `1`
+- `fr_gpio`: `2`
+- `bl_gpio`: `41`
+- `br_gpio`: `42`
+
+Default neutral angles are compatible with the original servo dog controller:
+
+- `fl_neutral`: `70`
+- `fr_neutral`: `110`
+- `bl_neutral`: `110`
+- `br_neutral`: `70`
+
+## Start Web Control
+
+Run the server script asynchronously. It starts the PWM worker, mounts the bundled web UI, and registers HTTP APIs.
+
+```json
+{
+  "path": "{CUR_SKILL_DIR}/scripts/servo_dog_server.lua",
+  "timeout_ms": 0,
+  "name": "servo_dog_server",
+  "exclusive": "servo_dog",
+  "replace": true,
+  "args": {
+    "app_id": "servo_dog",
+    "queue_name": "servo_dog_cmd",
+    "web_root": "{CUR_SKILL_DIR}/assets",
+    "worker_path": "{CUR_SKILL_DIR}/scripts/servo_dog_worker.lua",
+    "worker_args": {
+      "fl_gpio": 1,
+      "fr_gpio": 2,
+      "bl_gpio": 41,
+      "br_gpio": 42
+    }
+  }
+}
+```
+
+After it starts, open:
+
+```text
+/lua/servo_dog/
+```
+
+The page uses:
+
+- `GET /api/lua/servo_dog/state`
+- `POST /api/lua/servo_dog/control`
+- `GET /api/lua/servo_dog/start_calibration`
+- `GET /api/lua/servo_dog/exit_calibration`
+- `POST /api/lua/servo_dog/adjust`
+
+## Command Control
+
+For command or agent control, keep the server running and call:
+
+```json
+{
+  "path": "{CUR_SKILL_DIR}/scripts/servo_dog_command.lua",
+  "args": {
+    "queue_name": "servo_dog_cmd",
+    "action": "forward"
+  }
+}
+```
+
+If the command script reports that the controller is not running, start the web control script first.
+
+## Actions
+
+Supported action names:
+
+- `installation`
+- `idle`
+- `forward`
+- `backward`
+- `turn_left`
+- `turn_right`
+- `lay_down`
+- `bow`
+- `lean_back`
+- `bow_lean`
+- `sway_back_forth`
+- `sway`
+- `shake_hand`
+- `poke`
+- `shake_back_legs`
+- `jump_forward`
+- `jump_backward`
+- `retract_legs`
+
+Movement aliases:
+
+```json
+{"move":"F"}
+{"move":"B"}
+{"move":"L"}
+{"move":"R"}
+```
+
+Original web action id aliases:
+
+```json
+{"action":"1"}
+{"action":"2"}
+{"action":"3"}
+{"action":"4"}
+{"action":"5"}
+{"action":"6"}
+{"action":"7"}
+{"action":"8"}
+{"action":"9"}
+{"action":"10"}
+{"action":"11"}
+{"action":"12"}
+```
+
+These map to `lay_down`, `bow`, `lean_back`, `bow_lean`, `sway_back_forth`, `sway`, `shake_hand`, `poke`, `shake_back_legs`, `jump_forward`, `jump_backward`, and `retract_legs`.
+
+## Optional Action Args
+
+Some actions accept overrides:
+
+```json
+{
+  "action": "forward",
+  "args": {
+    "repeat_count": 3,
+    "speed": 90
+  }
+}
+```
+
+Supported fields are:
+
+- `repeat_count`: positive integer for repeated gait/action cycles.
+- `speed`: higher values shorten interpolation delay.
+- `hold_time_ms`: hold duration for actions such as `bow`, `lean_back`, and `shake_hand`.
+- `angle_offset`: offset used by `idle` and `sway`.
+
+## Calibration
+
+Start calibration from the web UI or send:
+
+```json
+{"action":"installation"}
+```
+
+Adjust one servo offset:
+
+```json
+{
+  "path": "{CUR_SKILL_DIR}/scripts/servo_dog_command.lua",
+  "args": {
+    "queue_name": "servo_dog_cmd",
+    "type": "adjust",
+    "servo": "fl",
+    "value": 3
+  }
+}
+```
+
+Valid servo ids are `fl`, `fr`, `bl`, and `br`. Values are clamped to `-25..25` and saved under the DATA root in `servo_dog/config.json`.
+
+## Extension
+
+To add a new dog action, edit `{CUR_SKILL_DIR}/scripts/servo_dog_worker.lua`:
+
+1. Add a Lua function that calls `set_angle()` or `set_angles()` and uses `action_delay(ms)` inside long loops.
+2. Register it in the `actions` table.
+3. Optionally add an alias in `action_aliases`.
+4. Add a button entry in the server `ACTIONS` list if the web UI should expose it.
+
+Use `action_delay()` instead of `delay.delay_ms()` inside actions so a new command can interrupt the current action.

--- a/skills/servo_dog/assets/app.js
+++ b/skills/servo_dog/assets/app.js
@@ -1,0 +1,232 @@
+const API = '/api/lua/servo_dog';
+
+const actionFallback = [
+  { id: '1', label: '趴下' },
+  { id: '2', label: '鞠躬' },
+  { id: '3', label: '后仰' },
+  { id: '4', label: '前后' },
+  { id: '5', label: '摇摆' },
+  { id: '6', label: '左右' },
+  { id: '7', label: '握手' },
+  { id: '8', label: '戳戳' },
+  { id: '9', label: '抖腿' },
+  { id: '10', label: '前跳' },
+  { id: '11', label: '后跳' },
+  { id: '12', label: '收腿' },
+];
+
+const state = {
+  offsets: { fl: 0, fr: 0, bl: 0, br: 0 },
+  selectedServo: null,
+  actions: actionFallback,
+  moves: [
+    { id: 'F', label: '前进' },
+    { id: 'B', label: '后退' },
+    { id: 'L', label: '左转' },
+    { id: 'R', label: '右转' },
+  ],
+  sequence: [],
+};
+
+function setStatus(text, isError = false) {
+  const el = document.getElementById('status');
+  el.textContent = text;
+  el.classList.toggle('error', isError);
+}
+
+async function request(path, body) {
+  const options = body === undefined ? {} : {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  };
+  const response = await fetch(`${API}${path}`, options);
+  const data = await response.json();
+  if (!response.ok || data.ok === false) {
+    throw new Error(data.error || '请求失败');
+  }
+  return data;
+}
+
+function renderActions() {
+  const actions = document.getElementById('actions');
+  const select = document.getElementById('sequence-action');
+  actions.innerHTML = '';
+  select.innerHTML = '';
+
+  state.actions.forEach((action) => {
+    const button = document.createElement('button');
+    button.textContent = action.label || action.name || action.id;
+    button.onclick = () => sendControl({ action: action.id || action.name });
+    actions.appendChild(button);
+
+    const option = document.createElement('option');
+    option.value = action.id || action.name;
+    option.textContent = action.label || action.name || action.id;
+    select.appendChild(option);
+  });
+
+  state.moves.forEach((move) => {
+    const option = document.createElement('option');
+    option.value = move.id;
+    option.textContent = move.label;
+    select.appendChild(option);
+  });
+}
+
+function renderOffsets() {
+  document.querySelectorAll('.servo').forEach((button) => {
+    const servo = button.dataset.servo;
+    button.querySelector('strong').textContent = state.offsets[servo] || 0;
+    button.classList.toggle('active', servo === state.selectedServo);
+  });
+
+  const label = document.getElementById('selected-servo');
+  label.textContent = state.selectedServo ? `${state.selectedServo}: ${state.offsets[state.selectedServo] || 0}` : '未选择';
+}
+
+function renderSequence() {
+  const list = document.getElementById('sequence-list');
+  list.innerHTML = '';
+  state.sequence.forEach((item, index) => {
+    const action = state.actions.find((candidate) => (candidate.id || candidate.name) === item.action)
+      || state.moves.find((candidate) => candidate.id === item.action);
+    const row = document.createElement('div');
+    row.className = 'sequence-item';
+    row.innerHTML = `
+      <span>${action ? action.label : item.action}</span>
+      <span>${item.delay}s</span>
+      <button class="remove" data-index="${index}" aria-label="remove">x</button>
+    `;
+    list.appendChild(row);
+  });
+}
+
+async function refreshState() {
+  try {
+    const data = await request('/state');
+    state.offsets = data.offsets || state.offsets;
+    state.actions = data.actions || actionFallback;
+    state.moves = data.moves || state.moves;
+    renderActions();
+    renderOffsets();
+    setStatus(data.calibration ? 'Calibration mode' : 'Ready');
+  } catch (error) {
+    setStatus(error.message, true);
+  }
+}
+
+async function sendControl(body) {
+  try {
+    await request('/control', body);
+    setStatus('Command sent');
+  } catch (error) {
+    setStatus(error.message, true);
+  }
+}
+
+function loadSequence() {
+  try {
+    const saved = localStorage.getItem('servoDogSequence');
+    state.sequence = saved ? JSON.parse(saved) : [];
+  } catch {
+    state.sequence = [];
+  }
+  renderSequence();
+}
+
+function bindControls() {
+  document.querySelectorAll('[data-move]').forEach((button) => {
+    button.onclick = () => sendControl({ move: button.dataset.move });
+  });
+
+  document.querySelectorAll('[data-action]').forEach((button) => {
+    button.onclick = () => sendControl({ action: button.dataset.action });
+  });
+
+  document.getElementById('start-calibration').onclick = async () => {
+    try {
+      const data = await request('/start_calibration');
+      state.offsets = data.offsets || state.offsets;
+      renderOffsets();
+      setStatus('Calibration mode');
+    } catch (error) {
+      setStatus(error.message, true);
+    }
+  };
+
+  document.getElementById('exit-calibration').onclick = async () => {
+    try {
+      await request('/exit_calibration');
+      setStatus('Ready');
+    } catch (error) {
+      setStatus(error.message, true);
+    }
+  };
+
+  document.querySelectorAll('.servo').forEach((button) => {
+    button.onclick = () => {
+      state.selectedServo = button.dataset.servo;
+      renderOffsets();
+    };
+  });
+
+  async function adjust(delta) {
+    if (!state.selectedServo) return;
+    const current = state.offsets[state.selectedServo] || 0;
+    const next = Math.max(-25, Math.min(25, current + delta));
+    state.offsets[state.selectedServo] = next;
+    renderOffsets();
+    try {
+      await request('/adjust', { servo: state.selectedServo, value: next });
+      setStatus('Offset saved');
+    } catch (error) {
+      setStatus(error.message, true);
+    }
+  }
+
+  document.getElementById('minus').onclick = () => adjust(-1);
+  document.getElementById('plus').onclick = () => adjust(1);
+
+  document.getElementById('add-sequence').onclick = () => {
+    if (state.sequence.length >= 8) {
+      setStatus('最多添加 8 个动作', true);
+      return;
+    }
+    const action = document.getElementById('sequence-action').value;
+    const delay = Number(document.getElementById('sequence-delay').value);
+    if (!action || Number.isNaN(delay) || delay < 0 || delay > 10) {
+      setStatus('延迟需在 0 到 10 秒之间', true);
+      return;
+    }
+    state.sequence.push({ action, delay });
+    renderSequence();
+  };
+
+  document.getElementById('sequence-list').onclick = (event) => {
+    if (!event.target.classList.contains('remove')) return;
+    state.sequence.splice(Number(event.target.dataset.index), 1);
+    renderSequence();
+  };
+
+  document.getElementById('save-sequence').onclick = () => {
+    localStorage.setItem('servoDogSequence', JSON.stringify(state.sequence));
+    setStatus('Sequence saved');
+  };
+
+  document.getElementById('play-sequence').onclick = async () => {
+    for (const item of state.sequence) {
+      const body = ['F', 'B', 'L', 'R'].includes(item.action)
+        ? { move: item.action }
+        : { action: item.action };
+      await sendControl(body);
+      await new Promise((resolve) => setTimeout(resolve, item.delay * 1000));
+    }
+  };
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  bindControls();
+  loadSequence();
+  refreshState();
+});

--- a/skills/servo_dog/assets/index.html
+++ b/skills/servo_dog/assets/index.html
@@ -1,0 +1,67 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Servo Dog</title>
+  <link rel="stylesheet" href="/lua/servo_dog/style.css">
+</head>
+<body>
+  <main class="shell">
+    <header class="topbar">
+      <h1>Servo Dog</h1>
+      <span id="status" class="status">Connecting</span>
+    </header>
+
+    <section class="panel">
+      <h2>移动</h2>
+      <div class="dpad" aria-label="movement controls">
+        <button data-move="F" class="move forward">前进</button>
+        <button data-move="L" class="move left">左转</button>
+        <button data-action="idle" class="move stop">停止</button>
+        <button data-move="R" class="move right">右转</button>
+        <button data-move="B" class="move back">后退</button>
+      </div>
+    </section>
+
+    <section class="panel">
+      <h2>动作</h2>
+      <div id="actions" class="button-grid"></div>
+    </section>
+
+    <section class="panel">
+      <h2>校准</h2>
+      <div class="calibration-row">
+        <button id="start-calibration">开始校准</button>
+        <button id="exit-calibration">退出校准</button>
+      </div>
+      <div class="servo-grid">
+        <button class="servo" data-servo="fl">前左 <strong>0</strong></button>
+        <button class="servo" data-servo="fr">前右 <strong>0</strong></button>
+        <button class="servo" data-servo="bl">后左 <strong>0</strong></button>
+        <button class="servo" data-servo="br">后右 <strong>0</strong></button>
+      </div>
+      <div class="adjust-row">
+        <button id="minus">-</button>
+        <span id="selected-servo">未选择</span>
+        <button id="plus">+</button>
+      </div>
+    </section>
+
+    <section class="panel">
+      <h2>动作序列</h2>
+      <div class="sequence-editor">
+        <select id="sequence-action"></select>
+        <input id="sequence-delay" type="number" value="0.5" min="0" max="10" step="0.1" aria-label="delay seconds">
+        <button id="add-sequence">添加</button>
+      </div>
+      <div id="sequence-list" class="sequence-list"></div>
+      <div class="calibration-row">
+        <button id="save-sequence">保存</button>
+        <button id="play-sequence">播放</button>
+      </div>
+    </section>
+  </main>
+  <script src="/lua/servo_dog/app.js"></script>
+</body>
+</html>

--- a/skills/servo_dog/assets/style.css
+++ b/skills/servo_dog/assets/style.css
@@ -1,0 +1,212 @@
+:root {
+  color-scheme: light;
+  --bg: #f7f8fa;
+  --text: #17202a;
+  --muted: #64748b;
+  --line: #d9e0ea;
+  --panel: #ffffff;
+  --accent: #0f766e;
+  --accent-strong: #0b5f59;
+  --warn: #b45309;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+button,
+select,
+input {
+  min-height: 42px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: #fff;
+  color: var(--text);
+  font: inherit;
+}
+
+button {
+  padding: 0 14px;
+  cursor: pointer;
+}
+
+button:active {
+  transform: translateY(1px);
+}
+
+.shell {
+  width: min(940px, 100%);
+  margin: 0 auto;
+  padding: 18px;
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+h1,
+h2 {
+  margin: 0;
+  letter-spacing: 0;
+}
+
+h1 {
+  font-size: 28px;
+}
+
+h2 {
+  font-size: 17px;
+  margin-bottom: 12px;
+}
+
+.status {
+  color: var(--muted);
+  font-size: 14px;
+  text-align: right;
+}
+
+.status.error {
+  color: #b91c1c;
+}
+
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 16px;
+  margin-bottom: 14px;
+}
+
+.dpad {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(72px, 1fr));
+  grid-template-areas:
+    ". forward ."
+    "left stop right"
+    ". back .";
+  gap: 10px;
+  max-width: 420px;
+}
+
+.move {
+  background: #edf7f6;
+  border-color: #b7dbd7;
+}
+
+.forward { grid-area: forward; }
+.left { grid-area: left; }
+.stop { grid-area: stop; background: #fff7ed; border-color: #fed7aa; }
+.right { grid-area: right; }
+.back { grid-area: back; }
+
+.button-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(92px, 1fr));
+  gap: 10px;
+}
+
+.button-grid button,
+.calibration-row button,
+.sequence-editor button,
+#play-sequence {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+
+.button-grid button:active,
+.calibration-row button:active,
+.sequence-editor button:active,
+#play-sequence:active {
+  background: var(--accent-strong);
+}
+
+.calibration-row,
+.adjust-row,
+.sequence-editor {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.servo-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(74px, 1fr));
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+.servo.active {
+  border-color: var(--warn);
+  box-shadow: 0 0 0 2px rgba(180, 83, 9, 0.14);
+}
+
+.servo strong {
+  display: block;
+  margin-top: 4px;
+}
+
+.adjust-row button {
+  width: 48px;
+  padding: 0;
+}
+
+.sequence-editor select {
+  flex: 1 1 180px;
+  padding: 0 10px;
+}
+
+.sequence-editor input {
+  width: 92px;
+  padding: 0 10px;
+}
+
+.sequence-list {
+  display: grid;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.sequence-item {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 10px;
+  align-items: center;
+  padding: 9px 10px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+}
+
+.remove {
+  min-height: 32px;
+  width: 32px;
+  padding: 0;
+}
+
+@media (max-width: 560px) {
+  .shell {
+    padding: 12px;
+  }
+
+  .topbar {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .servo-grid {
+    grid-template-columns: repeat(2, minmax(74px, 1fr));
+  }
+}

--- a/skills/servo_dog/scripts/servo_dog_command.lua
+++ b/skills/servo_dog/scripts/servo_dog_command.lua
@@ -1,0 +1,29 @@
+local json = require("json")
+local thread = require("thread")
+
+local sync = thread.sync
+
+local DEFAULT_QUEUE = "servo_dog_cmd"
+local raw_args = type(args) == "table" and args or {}
+local queue_name = type(raw_args.queue_name) == "string" and raw_args.queue_name ~= "" and raw_args.queue_name or DEFAULT_QUEUE
+
+local function copy_command()
+    local command = {}
+    for k, v in pairs(raw_args) do
+        if k ~= "queue_name" then
+            command[k] = v
+        end
+    end
+
+    if command.action == nil and command.move == nil and command.type == nil and command.name == nil then
+        command.action = "idle"
+    end
+    return command
+end
+
+local ok, err = sync.queue_send(queue_name, json.encode(copy_command()), 1000)
+if not ok then
+    error("[servo_dog] controller is not running; start servo_dog_server.lua first: " .. tostring(err))
+end
+
+print("[servo_dog] command sent")

--- a/skills/servo_dog/scripts/servo_dog_server.lua
+++ b/skills/servo_dog/scripts/servo_dog_server.lua
@@ -1,0 +1,217 @@
+local http = require("http_server")
+local json = require("json")
+local storage = require("storage")
+local thread = require("thread")
+
+local sync = thread.sync
+
+local DEFAULT_APP_ID = "servo_dog"
+local DEFAULT_QUEUE = "servo_dog_cmd"
+local DEFAULT_CONFIG_DIR = "servo_dog"
+local DEFAULT_CONFIG_FILE = "config.json"
+local DEFAULT_SKILL_DIR = "servo_dog"
+
+local function default_skill_path(...)
+    return storage.join_path(storage.get_root_dir(), "skills", DEFAULT_SKILL_DIR, ...)
+end
+
+local raw_args = type(args) == "table" and args or {}
+local app_id = type(raw_args.app_id) == "string" and raw_args.app_id ~= "" and raw_args.app_id or DEFAULT_APP_ID
+local queue_name = type(raw_args.queue_name) == "string" and raw_args.queue_name ~= "" and raw_args.queue_name or DEFAULT_QUEUE
+local web_root = type(raw_args.web_root) == "string" and raw_args.web_root ~= "" and raw_args.web_root or default_skill_path("assets")
+local worker_path = type(raw_args.worker_path) == "string" and raw_args.worker_path ~= "" and raw_args.worker_path or default_skill_path("scripts", "servo_dog_worker.lua")
+local worker_args = type(raw_args.worker_args) == "table" and raw_args.worker_args or {}
+worker_args.queue_name = queue_name
+
+local calibration_mode = false
+
+local ACTIONS = {
+    { id = "1", name = "lay_down", label = "趴下" },
+    { id = "2", name = "bow", label = "鞠躬" },
+    { id = "3", name = "lean_back", label = "后仰" },
+    { id = "4", name = "bow_lean", label = "前后" },
+    { id = "5", name = "sway_back_forth", label = "摇摆" },
+    { id = "6", name = "sway", label = "左右" },
+    { id = "7", name = "shake_hand", label = "握手" },
+    { id = "8", name = "poke", label = "戳戳" },
+    { id = "9", name = "shake_back_legs", label = "抖腿" },
+    { id = "10", name = "jump_forward", label = "前跳" },
+    { id = "11", name = "jump_backward", label = "后跳" },
+    { id = "12", name = "retract_legs", label = "收腿" },
+}
+
+local function config_path()
+    local root = storage.get_root_dir()
+    local dir = storage.join_path(root, DEFAULT_CONFIG_DIR)
+    pcall(storage.mkdir, dir)
+    return storage.join_path(dir, DEFAULT_CONFIG_FILE)
+end
+
+local function load_offsets()
+    local offset = { fl = 0, fr = 0, bl = 0, br = 0 }
+    local path = config_path()
+    if not storage.exists(path) then
+        return offset
+    end
+    local ok, data = pcall(json.decode, storage.read_file(path))
+    if ok and type(data) == "table" and type(data.offset) == "table" then
+        for _, leg in ipairs({ "fl", "fr", "bl", "br" }) do
+            offset[leg] = tonumber(data.offset[leg]) or 0
+        end
+    end
+    return offset
+end
+
+local function safe_app_id(value)
+    return type(value) == "string" and value:match("^[%w_-]+$") ~= nil
+end
+
+local function safe_abs_path(value)
+    return type(value) == "string" and value:sub(1, 1) == "/" and not value:find("%.%.", 1, true)
+end
+
+local function parse_body(body)
+    if type(body) ~= "string" or body == "" then
+        return {}
+    end
+    local ok, data = pcall(json.decode, body)
+    if not ok or type(data) ~= "table" then
+        return nil, "invalid JSON body"
+    end
+    return data
+end
+
+local function send_command(command)
+    local ok, err = sync.queue_send(queue_name, json.encode(command), 100)
+    if not ok then
+        return nil, err or "queue send failed"
+    end
+    return true
+end
+
+local function json_error(message, status)
+    return {
+        status = status or 400,
+        json = {
+            ok = false,
+            error = message,
+        },
+    }
+end
+
+local function start_worker()
+    pcall(thread.stop, "servo_dog_worker", 1000)
+    pcall(sync.queue_delete, queue_name)
+    assert(sync.queue_create(queue_name, { depth = 8, item_size = 2048 }))
+
+    local ok, output = thread.start(worker_path, worker_args, {
+        name = "servo_dog_worker",
+        exclusive = "servo_dog_worker",
+        replace = true,
+        timeout_ms = 0,
+    })
+    assert(ok, output)
+end
+
+local function register_routes(app)
+    app:get("/state", function(_req)
+        return {
+            json = {
+                ok = true,
+                calibration = calibration_mode,
+                offsets = load_offsets(),
+                actions = ACTIONS,
+                moves = {
+                    { id = "F", label = "前进" },
+                    { id = "B", label = "后退" },
+                    { id = "L", label = "左转" },
+                    { id = "R", label = "右转" },
+                },
+            },
+        }
+    end)
+
+    app:post("/control", function(req)
+        if calibration_mode then
+            return json_error("Control disabled in calibration mode", 400)
+        end
+        local body, err = parse_body(req.body)
+        if not body then
+            return json_error(err, 400)
+        end
+        local ok, send_err = send_command(body)
+        if not ok then
+            return json_error(send_err, 503)
+        end
+        return { json = { ok = true } }
+    end)
+
+    app:get("/start_calibration", function(_req)
+        calibration_mode = true
+        send_command({ action = "installation" })
+        return {
+            json = {
+                ok = true,
+                calibration = true,
+                offsets = load_offsets(),
+            },
+        }
+    end)
+
+    app:get("/exit_calibration", function(_req)
+        calibration_mode = false
+        send_command({ action = "idle" })
+        return { json = { ok = true, calibration = false } }
+    end)
+
+    app:post("/adjust", function(req)
+        local body, err = parse_body(req.body)
+        if not body then
+            return json_error(err, 400)
+        end
+        local servo = body.servo or body.leg
+        local value = tonumber(body.value)
+        if type(servo) ~= "string" or value == nil then
+            return json_error("servo and value are required", 400)
+        end
+        local ok, send_err = send_command({
+            type = "adjust",
+            servo = servo,
+            value = math.floor(value),
+        })
+        if not ok then
+            return json_error(send_err, 503)
+        end
+        return { json = { ok = true } }
+    end)
+end
+
+local function run()
+    if not safe_app_id(app_id) then
+        error("invalid app_id: " .. tostring(app_id))
+    end
+    if not safe_abs_path(web_root) then
+        error("invalid web_root: " .. tostring(web_root))
+    end
+    if not safe_abs_path(worker_path) then
+        error("invalid worker_path: " .. tostring(worker_path))
+    end
+
+    start_worker()
+
+    local app = http.app(app_id)
+    app:mount_static(web_root)
+    register_routes(app)
+
+    print("[servo_dog] serving " .. app:url() .. " from " .. web_root)
+    app:serve_forever()
+    pcall(thread.stop, "servo_dog_worker", 1000)
+    pcall(sync.queue_delete, queue_name)
+    print("[servo_dog] server stopped")
+end
+
+local ok, err = xpcall(run, debug.traceback)
+if not ok then
+    print("[servo_dog] ERROR: " .. tostring(err))
+    error(err)
+end

--- a/skills/servo_dog/scripts/servo_dog_worker.lua
+++ b/skills/servo_dog/scripts/servo_dog_worker.lua
@@ -1,0 +1,674 @@
+local delay = require("delay")
+local json = require("json")
+local mcpwm = require("mcpwm")
+local storage = require("storage")
+local thread = require("thread")
+
+local sync = thread.sync
+
+local DEFAULT_QUEUE = "servo_dog_cmd"
+local DEFAULT_GPIOS = { fl = 1, fr = 2, bl = 41, br = 42 }
+local DEFAULT_NEUTRAL = { fl = 70, fr = 110, bl = 110, br = 70 }
+local DEFAULT_MIN_PULSE_US = 500
+local DEFAULT_MAX_PULSE_US = 2500
+local DEFAULT_FREQUENCY_HZ = 50
+local DEFAULT_CONFIG_DIR = "servo_dog"
+local DEFAULT_CONFIG_FILE = "config.json"
+
+local BOW_OFFSET = 50
+local STEP_OFFSET = 5
+
+local raw_args = type(args) == "table" and args or {}
+local queue_name = type(raw_args.queue_name) == "string" and raw_args.queue_name ~= "" and raw_args.queue_name or DEFAULT_QUEUE
+
+local cfg = {
+    gpios = {
+        fl = tonumber(raw_args.fl_gpio) or DEFAULT_GPIOS.fl,
+        fr = tonumber(raw_args.fr_gpio) or DEFAULT_GPIOS.fr,
+        bl = tonumber(raw_args.bl_gpio) or DEFAULT_GPIOS.bl,
+        br = tonumber(raw_args.br_gpio) or DEFAULT_GPIOS.br,
+    },
+    neutral = {
+        fl = tonumber(raw_args.fl_neutral) or DEFAULT_NEUTRAL.fl,
+        fr = tonumber(raw_args.fr_neutral) or DEFAULT_NEUTRAL.fr,
+        bl = tonumber(raw_args.bl_neutral) or DEFAULT_NEUTRAL.bl,
+        br = tonumber(raw_args.br_neutral) or DEFAULT_NEUTRAL.br,
+    },
+    offset = { fl = 0, fr = 0, bl = 0, br = 0 },
+    min_pulse_us = tonumber(raw_args.min_pulse_us) or DEFAULT_MIN_PULSE_US,
+    max_pulse_us = tonumber(raw_args.max_pulse_us) or DEFAULT_MAX_PULSE_US,
+    frequency_hz = tonumber(raw_args.frequency_hz) or DEFAULT_FREQUENCY_HZ,
+}
+
+local pwm_front
+local pwm_back
+local pending_cmd
+
+local function config_path()
+    local root = storage.get_root_dir()
+    local dir = storage.join_path(root, DEFAULT_CONFIG_DIR)
+    pcall(storage.mkdir, dir)
+    return storage.join_path(dir, DEFAULT_CONFIG_FILE)
+end
+
+local function load_config()
+    local path = config_path()
+    if not storage.exists(path) then
+        return
+    end
+
+    local text = storage.read_file(path)
+    local ok, data = pcall(json.decode, text)
+    if not ok or type(data) ~= "table" then
+        return
+    end
+
+    if type(data.offset) == "table" then
+        for _, leg in ipairs({ "fl", "fr", "bl", "br" }) do
+            cfg.offset[leg] = tonumber(data.offset[leg]) or cfg.offset[leg]
+        end
+    end
+end
+
+local function save_config()
+    storage.write_file(config_path(), json.encode({ offset = cfg.offset }))
+end
+
+local function clamp(value, min_value, max_value)
+    if value < min_value then
+        return min_value
+    end
+    if value > max_value then
+        return max_value
+    end
+    return value
+end
+
+local function neutral(leg)
+    return cfg.neutral[leg] + cfg.offset[leg]
+end
+
+local function angle_to_duty_percent(angle)
+    local clamped = clamp(angle, 0, 180)
+    local pulse_width_us = cfg.min_pulse_us + (cfg.max_pulse_us - cfg.min_pulse_us) * clamped / 180
+    return pulse_width_us * cfg.frequency_hz / 10000
+end
+
+local function set_angle(leg, angle)
+    local duty = angle_to_duty_percent(angle)
+    if leg == "fl" then
+        pwm_front:set_duty(1, duty)
+    elseif leg == "fr" then
+        pwm_front:set_duty(2, duty)
+    elseif leg == "bl" then
+        pwm_back:set_duty(1, duty)
+    elseif leg == "br" then
+        pwm_back:set_duty(2, duty)
+    end
+end
+
+local function set_angles(angles)
+    if angles.fl then set_angle("fl", angles.fl) end
+    if angles.fr then set_angle("fr", angles.fr) end
+    if angles.bl then set_angle("bl", angles.bl) end
+    if angles.br then set_angle("br", angles.br) end
+end
+
+local function poll_command(timeout_ms)
+    local msg, err = sync.queue_recv(queue_name, timeout_ms)
+    if not msg then
+        return nil, err
+    end
+
+    local ok, data = pcall(json.decode, msg)
+    if ok and type(data) == "table" then
+        return data
+    end
+    return nil, "invalid"
+end
+
+local function action_delay(ms)
+    local cmd, err = poll_command(math.max(0, math.floor(ms or 0)))
+    if err == "stopped" then
+        error("stopped")
+    end
+    if cmd then
+        pending_cmd = cmd
+        return false
+    end
+    return true
+end
+
+local function neutral_pose(action_args)
+    local angle_offset = tonumber(action_args and action_args.angle_offset) or 0
+    set_angles({
+        fl = neutral("fl") + angle_offset,
+        fr = neutral("fr") - angle_offset,
+        bl = neutral("bl") - angle_offset,
+        br = neutral("br") + angle_offset,
+    })
+    return action_delay(20)
+end
+
+local function installation()
+    set_angles({
+        fl = neutral("fl") - 70,
+        fr = neutral("fr") + 70,
+        bl = neutral("bl") + 70,
+        br = neutral("br") - 70,
+    })
+    return action_delay(200)
+end
+
+local function step_delay(action_args)
+    local speed = tonumber(action_args.speed) or 80
+    if speed <= 0 then
+        speed = 80
+    end
+    return math.max(1, math.floor(500 / speed))
+end
+
+local function forward(action_args)
+    local repeat_count = tonumber(action_args.repeat_count) or 2
+    local d = step_delay(action_args)
+    local fl, fr, bl, br = neutral("fl"), neutral("fr"), neutral("bl"), neutral("br")
+
+    for _ = 1, repeat_count do
+        for i = 0, 39 do
+            set_angles({ fl = fl + 20 - i, br = br - 20 + i, bl = bl - 20 + i - STEP_OFFSET, fr = fr + 20 - i - STEP_OFFSET })
+            if not action_delay(d) then return end
+        end
+        if not action_delay(50) then return end
+        for i = 0, 39 do
+            set_angles({ fl = fl - 20 + i, br = br + 20 - i, bl = bl + 20 - i + STEP_OFFSET, fr = fr - 20 + i + STEP_OFFSET })
+            if not action_delay(d) then return end
+        end
+        if not action_delay(50) then return end
+    end
+
+    for i = 0, 19 do
+        set_angles({ fl = fl + 20 - i, br = br - 20 + i, bl = bl - 20 + i, fr = fr + 20 - i })
+        if not action_delay(d) then return end
+    end
+end
+
+local function backward(action_args)
+    local repeat_count = tonumber(action_args.repeat_count) or 2
+    local d = step_delay(action_args)
+    local fl, fr, bl, br = neutral("fl"), neutral("fr"), neutral("bl"), neutral("br")
+
+    for _ = 1, repeat_count do
+        for i = 0, 39 do
+            set_angles({ bl = bl + 20 - i, fr = fr - 20 + i, fl = fl - 20 + i - STEP_OFFSET, br = br + 20 - i - STEP_OFFSET })
+            if not action_delay(d) then return end
+        end
+        if not action_delay(50) then return end
+        for i = 0, 39 do
+            set_angles({ bl = bl - 20 + i, fr = fr + 20 - i, fl = fl + 20 - i + STEP_OFFSET, br = br - 20 + i + STEP_OFFSET })
+            if not action_delay(d) then return end
+        end
+        if not action_delay(50) then return end
+    end
+
+    for i = 0, 19 do
+        set_angles({ bl = bl + 20 - i, fr = fr - 20 + i, fl = fl - 20 + i, br = br + 20 - i })
+        if not action_delay(d) then return end
+    end
+end
+
+local function turn_left(action_args)
+    local repeat_count = tonumber(action_args.repeat_count) or 2
+    local d = step_delay(action_args)
+    local fl, fr, bl, br = neutral("fl"), neutral("fr"), neutral("bl"), neutral("br")
+
+    for _ = 1, repeat_count do
+        for i = 0, 39 do
+            set_angles({ fl = fl + 20 - i + STEP_OFFSET, br = br + 20 - i + STEP_OFFSET, bl = bl - 20 + i, fr = fr - 20 + i })
+            if not action_delay(d) then return end
+        end
+        for i = 0, 39 do
+            set_angles({ fl = fl - 20 + i - STEP_OFFSET, br = br - 20 + i - STEP_OFFSET, bl = bl + 20 - i, fr = fr + 20 - i })
+            if not action_delay(d) then return end
+        end
+    end
+
+    for i = 0, 19 do
+        set_angles({ fl = fl + 20 - i, br = br + 20 - i, bl = bl - 20 + i, fr = fr - 20 + i })
+        if not action_delay(d) then return end
+    end
+end
+
+local function turn_right(action_args)
+    local repeat_count = tonumber(action_args.repeat_count) or 2
+    local d = step_delay(action_args)
+    local fl, fr, bl, br = neutral("fl"), neutral("fr"), neutral("bl"), neutral("br")
+
+    for _ = 1, repeat_count do
+        for i = 0, 39 do
+            set_angles({ fl = fl - 20 + i, br = br - 20 + i, bl = bl + 20 - i + STEP_OFFSET, fr = fr + 20 - i + STEP_OFFSET })
+            if not action_delay(d) then return end
+        end
+        for i = 0, 39 do
+            set_angles({ fl = fl + 20 - i - STEP_OFFSET, br = br + 20 - i - STEP_OFFSET, bl = bl - 20 + i, fr = fr - 20 + i })
+            if not action_delay(d) then return end
+        end
+    end
+
+    for i = 0, 19 do
+        set_angles({ fl = fl - 20 + i, br = br - 20 + i, bl = bl + 20 - i, fr = fr + 20 - i })
+        if not action_delay(d) then return end
+    end
+end
+
+local function bow(action_args)
+    local d = step_delay(action_args)
+    local hold = tonumber(action_args.hold_time_ms) or 500
+    local fl, fr, bl, br = neutral("fl"), neutral("fr"), neutral("bl"), neutral("br")
+
+    for i = 0, BOW_OFFSET - 1 do
+        set_angles({ fl = fl - i, fr = fr + i, bl = bl - i, br = br + i })
+        if not action_delay(d) then return end
+    end
+    if not action_delay(hold) then return end
+    for i = 0, BOW_OFFSET - 1 do
+        set_angles({ fl = fl - BOW_OFFSET + i, fr = fr + BOW_OFFSET - i, bl = bl - BOW_OFFSET + i, br = br + BOW_OFFSET - i })
+        if not action_delay(d) then return end
+    end
+end
+
+local function lean_back(action_args)
+    local d = step_delay(action_args)
+    local hold = tonumber(action_args.hold_time_ms) or 500
+    local fl, fr, bl, br = neutral("fl"), neutral("fr"), neutral("bl"), neutral("br")
+
+    for i = 0, BOW_OFFSET - 1 do
+        set_angles({ fl = fl + i, fr = fr - i, bl = bl + i, br = br - i })
+        if not action_delay(d) then return end
+    end
+    if not action_delay(hold) then return end
+    for i = 0, BOW_OFFSET - 1 do
+        set_angles({ fl = fl + BOW_OFFSET - i, fr = fr - BOW_OFFSET + i, bl = bl + BOW_OFFSET - i, br = br - BOW_OFFSET + i })
+        if not action_delay(d) then return end
+    end
+end
+
+local function bow_and_lean_back(action_args)
+    local d = step_delay(action_args)
+    local repeat_count = tonumber(action_args.repeat_count) or 2
+    local fl, fr, bl, br = neutral("fl"), neutral("fr"), neutral("bl"), neutral("br")
+
+    for i = 0, BOW_OFFSET - 1 do
+        set_angles({ fl = fl - i, fr = fr + i, bl = bl - i, br = br + i })
+        if not action_delay(d) then return end
+    end
+    for _ = 1, repeat_count do
+        for i = 0, BOW_OFFSET * 2 - 1 do
+            set_angles({ fl = fl - BOW_OFFSET + i, fr = fr + BOW_OFFSET - i, bl = bl - BOW_OFFSET + i, br = br + BOW_OFFSET - i })
+            if not action_delay(d) then return end
+        end
+        for i = 0, BOW_OFFSET * 2 - 1 do
+            set_angles({ fl = fl + BOW_OFFSET - i, fr = fr - BOW_OFFSET + i, bl = bl + BOW_OFFSET - i, br = br - BOW_OFFSET + i })
+            if not action_delay(d) then return end
+        end
+    end
+    for i = 0, BOW_OFFSET - 1 do
+        set_angles({ fl = fl - BOW_OFFSET + i, fr = fr + BOW_OFFSET - i, bl = bl - BOW_OFFSET + i, br = br + BOW_OFFSET - i })
+        if not action_delay(d) then return end
+    end
+end
+
+local function sway_back_and_forth()
+    local fl, fr, bl, br = neutral("fl"), neutral("fr"), neutral("bl"), neutral("br")
+    local sway_offset = 18
+    for i = 0, sway_offset - 1 do
+        set_angles({ fl = fl - i, fr = fr + i, bl = bl - i, br = br + i })
+        if not action_delay(5) then return end
+    end
+    while sway_offset > 0 and sway_offset <= 18 do
+        for i = 0, sway_offset * 2 - 1 do
+            set_angles({ fl = fl - sway_offset + i, fr = fr + sway_offset - i, bl = bl - sway_offset + i, br = br + sway_offset - i })
+            if not action_delay(5) then return end
+        end
+        for i = 0, sway_offset * 2 - 1 do
+            set_angles({ fl = fl + sway_offset - i, fr = fr - sway_offset + i, bl = bl + sway_offset - i, br = br - sway_offset + i })
+            if not action_delay(5) then return end
+        end
+        sway_offset = sway_offset - 3
+    end
+end
+
+local function lay_down()
+    local fl, fr, bl, br = neutral("fl"), neutral("fr"), neutral("bl"), neutral("br")
+    for i = 0, 59 do
+        set_angles({ fl = fl - i, fr = fr + i, bl = bl + i, br = br - i })
+        if not action_delay(10) then return end
+    end
+end
+
+local function sway_left_right(action_args)
+    local d = step_delay(action_args)
+    local repeat_count = tonumber(action_args.repeat_count) or 2
+    local angle_offset = tonumber(action_args.angle_offset) or 20
+    local fl, fr, bl, br = neutral("fl"), neutral("fr"), neutral("bl"), neutral("br")
+
+    neutral_pose({ angle_offset = 20 })
+    for _ = 1, repeat_count do
+        for i = 0, angle_offset - 1 do
+            set_angles({ fl = fl + 20 - i, fr = fr - 20 - i, bl = bl - 20 - i, br = br + 20 - i })
+            if not action_delay(d) then return end
+        end
+        for i = 0, angle_offset * 2 - 1 do
+            set_angles({ fl = fl + 20 - angle_offset + i, fr = fr - 20 - angle_offset + i, bl = bl - 20 - angle_offset + i, br = br + 20 - angle_offset + i })
+            if not action_delay(d) then return end
+        end
+        for i = 0, angle_offset - 1 do
+            set_angles({ fl = fl + 20 + angle_offset - i, fr = fr - 20 + angle_offset - i, bl = bl - 20 + angle_offset - i, br = br + 20 + angle_offset - i })
+            if not action_delay(d) then return end
+        end
+    end
+end
+
+local function shake_hand(action_args)
+    local repeat_count = tonumber(action_args.repeat_count) or 10
+    local hold = tonumber(action_args.hold_time_ms) or 3000
+    local fr, bl, br = neutral("fr"), neutral("bl"), neutral("br")
+
+    for i = 0, 59 do
+        set_angles({ bl = bl - i, br = br + i })
+        if not action_delay(8) then return end
+    end
+    local start_angle = fr + 72
+    local end_angle = fr + 57
+    set_angle("fr", start_angle)
+    for _ = 1, repeat_count do
+        for angle = start_angle, end_angle, -1 do
+            set_angle("fr", angle)
+            if not action_delay(15) then return end
+        end
+        for angle = end_angle, start_angle do
+            set_angle("fr", angle)
+            if not action_delay(15) then return end
+        end
+    end
+    if not action_delay(hold) then return end
+    for angle = start_angle, fr, -1 do
+        set_angle("fr", angle)
+        if not action_delay(5) then return end
+    end
+    for i = 0, 59 do
+        set_angles({ bl = bl - 60 + i, br = br + 60 - i })
+        if not action_delay(8) then return end
+    end
+end
+
+local function jump_forward(action_args)
+    local fl, fr, bl, br = neutral("fl"), neutral("fr"), neutral("bl"), neutral("br")
+    neutral_pose(action_args)
+    if not action_delay(300) then return end
+    set_angles({ fl = fl - 30, fr = fr + 30, bl = bl - 60, br = br + 60 })
+    if not action_delay(300) then return end
+    set_angles({ fl = fl + 70, fr = fr - 70 })
+    if not action_delay(40) then return end
+    set_angles({ fl = fl - 70, fr = fr + 70 })
+    if not action_delay(20) then return end
+    set_angles({ bl = bl + 20, br = br - 20 })
+    if not action_delay(150) then return end
+    set_angles({ fl = fl, fr = fr })
+    action_delay(200)
+end
+
+local function jump_backward(action_args)
+    local fl, fr, bl, br = neutral("fl"), neutral("fr"), neutral("bl"), neutral("br")
+    set_angles({ fl = fl + 40, fr = fr - 40, bl = bl + 20, br = br - 20 })
+    if not action_delay(100) then return end
+    set_angles({ fl = fl + 20, fr = fr - 20, bl = bl - 20, br = br + 20 })
+    if not action_delay(100) then return end
+    set_angles({ fl = fl, fr = fr, bl = bl + 20, br = br - 20 })
+    if not action_delay(150) then return end
+    neutral_pose(action_args)
+end
+
+local function poke(action_args)
+    local fr, bl, br = neutral("fr"), neutral("bl"), neutral("br")
+    set_angle("fl", 0)
+    if not action_delay(20) then return end
+    for i = 0, 4 do
+        set_angles({ fr = fr + i, bl = bl - 10 * i, br = br + 10 * i })
+        if not action_delay(10) then return end
+    end
+    for _ = 1, 2 do
+        for i = 0, 19 do
+            set_angles({ fr = fr + 5 + i, bl = bl - 50 - i, br = br + 50 + i })
+            if not action_delay(20) then return end
+        end
+        for i = 0, 19 do
+            set_angles({ fr = fr + 25 - i, bl = bl - 70 + i, br = br + 70 - i })
+            if not action_delay(20) then return end
+        end
+    end
+    neutral_pose(action_args)
+end
+
+local function shake_back_legs()
+    local fl, fr, bl, br = neutral("fl"), neutral("fr"), neutral("bl"), neutral("br")
+    for i = 0, 17 do
+        set_angles({ fl = fl + 2 * i, fr = fr - 2 * i, bl = bl + 3 * i, br = br - 3 * i })
+        if not action_delay(15) then return end
+    end
+    for _ = 1, 12 do
+        for i = 0, 5 do
+            set_angles({ bl = bl + 54 + i, br = br - 54 + i })
+            if not action_delay(7) then return end
+        end
+        for i = 0, 11 do
+            set_angles({ bl = bl + 54 - i, br = br - 54 - i })
+            if not action_delay(7) then return end
+        end
+        for i = 0, 5 do
+            set_angles({ bl = bl + 54 + i, br = br - 54 + i })
+            if not action_delay(7) then return end
+        end
+    end
+    for i = 0, 17 do
+        set_angles({ fl = fl + 36 - 2 * i, fr = fr - 36 + 2 * i, bl = bl + 54 - 3 * i, br = br - 54 + 3 * i })
+        if not action_delay(15) then return end
+    end
+end
+
+local function retract_legs()
+    local fl, fr, bl, br = neutral("fl"), neutral("fr"), neutral("bl"), neutral("br")
+    for i = 0, 109 do
+        set_angles({ fl = fl + i, fr = fr - i })
+        if not action_delay(4) then return end
+    end
+    for i = 0, 102 do
+        set_angles({ bl = bl - i, br = br + i })
+        if not action_delay(4) then return end
+    end
+end
+
+local actions = {
+    installation = { fn = installation },
+    idle = { fn = neutral_pose, args = { angle_offset = 0 } },
+    forward = { fn = forward, args = { repeat_count = 2, speed = 80 } },
+    backward = { fn = backward, args = { repeat_count = 2, speed = 80 } },
+    turn_right = { fn = turn_right, args = { repeat_count = 2, speed = 80 } },
+    turn_left = { fn = turn_left, args = { repeat_count = 2, speed = 80 } },
+    lay_down = { fn = lay_down },
+    bow = { fn = bow, args = { speed = 80, hold_time_ms = 500 } },
+    lean_back = { fn = lean_back, args = { speed = 80, hold_time_ms = 500 } },
+    bow_lean = { fn = bow_and_lean_back, args = { repeat_count = 2, speed = 80 } },
+    sway_back_forth = { fn = sway_back_and_forth },
+    sway = { fn = sway_left_right, args = { repeat_count = 2, speed = 40, angle_offset = 20 } },
+    shake_hand = { fn = shake_hand, args = { repeat_count = 10, hold_time_ms = 3000 } },
+    poke = { fn = poke },
+    shake_back_legs = { fn = shake_back_legs },
+    jump_forward = { fn = jump_forward },
+    jump_backward = { fn = jump_backward },
+    retract_legs = { fn = retract_legs },
+}
+
+local action_aliases = {
+    F = "forward",
+    B = "backward",
+    L = "turn_left",
+    R = "turn_right",
+    ["1"] = "lay_down",
+    ["2"] = "bow",
+    ["3"] = "lean_back",
+    ["4"] = "bow_lean",
+    ["5"] = "sway_back_forth",
+    ["6"] = "sway",
+    ["7"] = "shake_hand",
+    ["8"] = "poke",
+    ["9"] = "shake_back_legs",
+    ["10"] = "jump_forward",
+    ["11"] = "jump_backward",
+    ["12"] = "retract_legs",
+}
+
+local function merge_args(base, override)
+    local out = {}
+    if type(base) == "table" then
+        for k, v in pairs(base) do out[k] = v end
+    end
+    if type(override) == "table" then
+        for k, v in pairs(override) do out[k] = v end
+    end
+    return out
+end
+
+local function resolve_action(cmd)
+    local name = cmd.action or cmd.move or cmd.name
+    if type(name) == "number" then
+        name = tostring(math.floor(name))
+    end
+    if type(name) ~= "string" then
+        return nil
+    end
+    return action_aliases[name] or name
+end
+
+local function run_action(name, action_args)
+    local entry = actions[name]
+    if not entry then
+        print("[servo_dog] unknown action: " .. tostring(name))
+        return
+    end
+    print("[servo_dog] action: " .. name)
+    entry.fn(merge_args(entry.args, action_args))
+end
+
+local function adjust(cmd)
+    local leg = cmd.servo or cmd.leg
+    local value = tonumber(cmd.value)
+    if not cfg.offset[leg] or value == nil then
+        print("[servo_dog] invalid adjust command")
+        return
+    end
+    cfg.offset[leg] = clamp(math.floor(value), -25, 25)
+    save_config()
+    installation()
+end
+
+local function direct_angles(cmd)
+    if type(cmd.angles) ~= "table" then
+        return
+    end
+    set_angles({
+        fl = tonumber(cmd.angles.fl),
+        fr = tonumber(cmd.angles.fr),
+        bl = tonumber(cmd.angles.bl),
+        br = tonumber(cmd.angles.br),
+    })
+end
+
+local function handle_command(cmd)
+    if cmd.type == "adjust" then
+        adjust(cmd)
+        return
+    end
+    if cmd.type == "angles" then
+        direct_angles(cmd)
+        return
+    end
+    if cmd.type == "save_offsets" and type(cmd.offset) == "table" then
+        for _, leg in ipairs({ "fl", "fr", "bl", "br" }) do
+            cfg.offset[leg] = clamp(math.floor(tonumber(cmd.offset[leg]) or cfg.offset[leg]), -25, 25)
+        end
+        save_config()
+        installation()
+        return
+    end
+    if cmd.type == "stop" then
+        neutral_pose({ angle_offset = 0 })
+        return
+    end
+
+    local name = resolve_action(cmd)
+    if name then
+        run_action(name, cmd.args)
+    end
+end
+
+local function cleanup()
+    if pwm_front then
+        pcall(pwm_front.stop, pwm_front)
+        pcall(pwm_front.close, pwm_front)
+        pwm_front = nil
+    end
+    if pwm_back then
+        pcall(pwm_back.stop, pwm_back)
+        pcall(pwm_back.close, pwm_back)
+        pwm_back = nil
+    end
+end
+
+local function run()
+    load_config()
+    pwm_front = mcpwm.new({
+        gpio = cfg.gpios.fl,
+        gpio_b = cfg.gpios.fr,
+        frequency_hz = cfg.frequency_hz,
+        duty_percent = angle_to_duty_percent(neutral("fl")),
+        duty_percent_b = angle_to_duty_percent(neutral("fr")),
+    })
+    pwm_back = mcpwm.new({
+        gpio = cfg.gpios.bl,
+        gpio_b = cfg.gpios.br,
+        frequency_hz = cfg.frequency_hz,
+        duty_percent = angle_to_duty_percent(neutral("bl")),
+        duty_percent_b = angle_to_duty_percent(neutral("br")),
+    })
+    pwm_front:start()
+    pwm_back:start()
+    neutral_pose({ angle_offset = 0 })
+    print(string.format("[servo_dog] worker ready queue=%s gpios=%d,%d,%d,%d",
+        queue_name, cfg.gpios.fl, cfg.gpios.fr, cfg.gpios.bl, cfg.gpios.br))
+
+    while true do
+        local cmd = pending_cmd
+        pending_cmd = nil
+        if not cmd then
+            local err
+            cmd, err = poll_command(1000)
+            if err == "stopped" then
+                return
+            end
+        end
+        if cmd then
+            handle_command(cmd)
+        end
+    end
+end
+
+local ok, err = xpcall(run, debug.traceback)
+cleanup()
+if not ok then
+    if tostring(err):find("stopped", 1, true) then
+        print("[servo_dog] worker stopped")
+        return
+    end
+    print("[servo_dog] ERROR: " .. tostring(err))
+    error(err)
+end


### PR DESCRIPTION
## Description

This PR adds a new Lua skill implementation for controlling a quadruped servo dog.

### Features

* Added a `servo_dog` Lua skill.

* Default servo GPIOs are:

  * Front Left: GPIO1
  * Front Right: GPIO2
  * Rear Left: GPIO41
  * Rear Right: GPIO42

* Generates standard 50 Hz servo PWM using the Lua MCPWM API.

* Supports servo offset calibration and persists calibration values to:

  ```
  DATA_ROOT/servo_dog/config.json
  ```

### Built-in Actions

The skill implements a set of predefined motions:

* Forward
* Backward
* Turn left
* Turn right
* Lie down
* Bow
* Lean backward
* Rock front/back
* Rock left/right
* Handshake
* Poke
* Shake leg
* Jump forward
* Jump backward
* Retract legs

### Control Interfaces

#### Web UI

The skill exposes a web page:

```
/lua/servo_dog/
```

#### HTTP API

Motion control APIs are available under:

```
/api/lua/servo_dog/...
```

#### Command-Based Control

`servo_dog_command.lua` provides command control by sending actions into the same worker queue, allowing multiple control methods to share a unified execution path.

### Extensibility

All actions are registered centrally inside the worker through an action mapping table.

To add a new motion, only two steps are required:

1. Implement the motion function.
2. Add the corresponding action mapping.

This design keeps the motion framework simple and makes future extensions straightforward.

### Motivation

This skill demonstrates how Lua can be used to implement device-level behaviors and expose them through Web UI, HTTP APIs, and command interfaces while sharing a common execution queue. It also serves as an example of building reusable robot behaviors on top of the Lua runtime.
