### PR TITLE
feat(skills): add game skills

### DIFF
--- a/skills/game_2048/SKILL.md
+++ b/skills/game_2048/SKILL.md
@@ -1,0 +1,57 @@
+---
+{
+  "name": "game_2048",
+  "description": "Play a touch-swipe 2048 puzzle game on the LCD with sliding tile animation and pixel-style sound effects.",
+  "author": "ESP-Claw contributor",
+  "metadata": {
+    "category": ["game", "ui"],
+    "tags": ["2048", "puzzle", "touch", "slide", "pixel", "sound"],
+    "peripherals": ["display"],
+    "cap_groups": ["cap_lua"],
+    "manage_mode": "web"
+  },
+  "simulator": {
+    "entry": "scripts/game_2048.lua",
+    "files": [
+      "scripts/game_2048.lua"
+    ]
+  }
+}
+---
+
+# Game_ 2048
+
+Use this skill when the user asks to play 2048, a sliding number puzzle, or a touch-swipe LCD game.
+
+The Lua script renders a 480x480-centered 2048 board when enough screen space is available. Swipe up, down, left, or right on the LCD to move tiles. Matching tiles merge, score increases, and the game ends when no moves remain.
+
+## Requirements
+
+- A display device declared as `display_lcd` in board hardware info.
+- LCD touch input declared as `lcd_touch`.
+- Audio output is optional and used for pixel-style move, merge, new-game, and game-over sound effects.
+
+## Tool Call Inputs
+
+```json
+{
+  "path": "{CUR_SKILL_DIR}/scripts/game_2048.lua",
+  "args": {}
+}
+```
+
+Optional args:
+
+| Arg | Default | Meaning |
+|-----|---------|---------|
+| `run_time_ms` | `180000` | Game duration in milliseconds |
+| `sample_rate_hz` | board `audio_dac` rate | Output sample rate for sound effects |
+| `target_size` | `480` | Square game stage size when screen space allows |
+
+## Behavior
+
+Swipe to move tiles. The script plays a short move tone after any valid slide and a brighter merge tone when a merge happens. On startup failure it prints a single `[game_2048] ERROR: ...` line which should be reported directly to the user.
+
+## Files
+
+- `scripts/game_2048.lua`

--- a/skills/game_2048/scripts/game_2048.lua
+++ b/skills/game_2048/scripts/game_2048.lua
@@ -1,0 +1,678 @@
+local bm = require("board_manager")
+local display = require("display")
+local delay = require("delay")
+local system_ok, system = pcall(require, "system")
+local touch_ok, lcd_touch = pcall(require, "lcd_touch")
+local audio_ok, audio = pcall(require, "audio")
+
+local a = type(args) == "table" and args or {}
+
+local function int_arg(name, default)
+    local value = a[name]
+    if type(value) == "number" then
+        return math.floor(value)
+    end
+    return default
+end
+
+local function now_ms()
+    if system_ok and system and system.millis then
+        return system.millis()
+    end
+    return math.floor(os.clock() * 1000)
+end
+
+local function rgb(r, g, b)
+    return { r = r, g = g, b = b }
+end
+
+local function clamp(v, lo, hi)
+    if v < lo then return lo end
+    if v > hi then return hi end
+    return v
+end
+
+local RUN_TIME_MS = int_arg("run_time_ms", 180000)
+local TARGET_SIZE = clamp(int_arg("target_size", 480), 240, 800)
+local FRAME_MS = 16
+local SWIPE_THRESHOLD = 44
+local SOUND_VOLUME = 84
+local UAC_FLUSH_PCM_BYTES = 4000
+
+local output_codec, board_output_rate, output_channels, output_bits =
+    bm.get_audio_codec_output_params("audio_dac")
+local OUTPUT_SAMPLE_RATE = int_arg("sample_rate_hz", board_output_rate or 16000)
+
+local panel, io, width, height, panel_if = bm.get_display_lcd_params("display_lcd")
+if not panel then
+    print("[game_2048] ERROR: get_display_lcd_params(display_lcd) failed: " .. tostring(io))
+    return
+end
+
+local ok, err = pcall(display.init, panel, io, width, height, panel_if)
+if not ok then
+    print("[game_2048] ERROR: display.init failed: " .. tostring(err))
+    return
+end
+
+local screen_ready = true
+width = display.width
+height = display.height
+
+local touch_handle = nil
+local audio_output = nil
+local sfx = {}
+local pending_sfx = nil
+
+local function cleanup()
+    if audio_output then
+        pcall(audio_output.close, audio_output)
+        audio_output = nil
+    end
+    if screen_ready then
+        pcall(display.end_frame)
+        pcall(display.deinit)
+        screen_ready = false
+    end
+end
+
+if width <= 0 or height <= 0 then
+    print("[game_2048] ERROR: invalid display size")
+    cleanup()
+    return
+end
+
+if not touch_ok then
+    print("[game_2048] ERROR: require(lcd_touch) failed")
+    cleanup()
+    return
+end
+
+local touch_err
+touch_handle, touch_err = bm.get_lcd_touch_handle("lcd_touch")
+if not touch_handle then
+    print("[game_2048] ERROR: get_lcd_touch_handle(lcd_touch) failed: " .. tostring(touch_err))
+    cleanup()
+    return
+end
+
+local synced, sync_err = pcall(lcd_touch.sync, touch_handle)
+if not synced then
+    print("[game_2048] ERROR: lcd_touch.sync failed: " .. tostring(sync_err))
+    cleanup()
+    return
+end
+
+local function build_tone(freq_hz, duration_ms, amp, wave)
+    local rate = OUTPUT_SAMPLE_RATE
+    local frames = math.floor(rate * duration_ms / 1000)
+    if frames <= 0 then
+        return string.rep("\0", UAC_FLUSH_PCM_BYTES)
+    end
+
+    local chunks = {}
+    local phase = 0
+    local step = 2 * math.pi * freq_hz / rate
+    for i = 1, frames do
+        local raw
+        if wave == "square" then
+            raw = math.sin(phase) >= 0 and 1 or -1
+        else
+            raw = math.sin(phase)
+        end
+        local fade = 1
+        if i > frames * 0.72 then
+            fade = (frames - i) / math.max(1, frames * 0.28)
+        end
+        local sample = math.floor(raw * amp * fade)
+        phase = phase + step
+        if sample > 32767 then sample = 32767 end
+        if sample < -32768 then sample = -32768 end
+        local u = sample < 0 and sample + 65536 or sample
+        chunks[i] = string.char(u % 256, math.floor(u / 256) % 256)
+    end
+
+    local pcm = table.concat(chunks)
+    if #pcm < UAC_FLUSH_PCM_BYTES then
+        pcm = pcm .. string.rep("\0", UAC_FLUSH_PCM_BYTES - #pcm)
+    end
+    return pcm
+end
+
+local function init_audio()
+    if not audio_ok or not output_codec then
+        print("[game_2048] WARN: audio unavailable")
+        return
+    end
+
+    local out_ok, out = pcall(function()
+        return audio.new_output({
+            codec = output_codec,
+            sample_rate = OUTPUT_SAMPLE_RATE,
+            channels = output_channels,
+            bits = output_bits,
+            volume = SOUND_VOLUME,
+        })
+    end)
+    if not out_ok or not out then
+        print("[game_2048] WARN: audio init failed: " .. tostring(out))
+        return
+    end
+
+    audio_output = out
+    sfx.start = build_tone(660, 80, 12000, "square")
+    sfx.move = build_tone(360, 48, 9000, "square")
+    sfx.merge = build_tone(920, 80, 13000, "square")
+    sfx.block = build_tone(150, 70, 9000, "square")
+    sfx.over = build_tone(180, 240, 11000, "square")
+    pending_sfx = sfx.start
+end
+
+local function request_sfx(name)
+    if sfx[name] then
+        pending_sfx = sfx[name]
+    end
+end
+
+local function drain_sfx()
+    if not pending_sfx or not audio_output then
+        return
+    end
+    local pcm = pending_sfx
+    local wrote, write_err = audio_output:write(pcm)
+    if wrote or (write_err and not tostring(write_err):find("busy", 1, true)) then
+        pending_sfx = nil
+    end
+end
+
+init_audio()
+
+local stage = math.min(TARGET_SIZE, width, height)
+local sx = math.floor((width - stage) / 2)
+local sy = math.floor((height - stage) / 2)
+local margin = math.max(10, math.floor(stage * 0.028))
+local header_h = math.max(52, math.floor(stage * 0.135))
+local gap = math.max(5, math.floor(stage * 0.014))
+local board_size = stage - margin * 2 - header_h
+board_size = board_size - (board_size % 4)
+local cell = math.floor((board_size - gap * 5) / 4)
+board_size = cell * 4 + gap * 5
+local board_x = sx + math.floor((stage - board_size) / 2)
+local board_y = sy + header_h + math.floor((stage - header_h - board_size) / 2)
+
+local BG = rgb(248, 245, 239)
+local STAGE_BG = rgb(248, 245, 239)
+local PANEL = rgb(157, 143, 132)
+local GRID = rgb(187, 175, 165)
+local EMPTY = rgb(205, 196, 187)
+local BOARD_SHADOW = rgb(222, 214, 205)
+local SEPARATOR = rgb(216, 207, 197)
+local TEXT = rgb(255, 250, 244)
+local TITLE_TEXT = rgb(91, 84, 77)
+local SUBTEXT = rgb(239, 232, 224)
+local GOLD = rgb(237, 194, 46)
+local RED = rgb(246, 94, 59)
+local GHOST_COLORS = {
+    rgb(230, 222, 213),
+    rgb(218, 207, 197),
+    rgb(205, 192, 181),
+    rgb(192, 177, 165),
+}
+local GHOST_VALUES = {
+    "0", "1", "2", "3", "4", "5", "6", "7", "8", "9",
+    "16", "32", "64", "128", "256", "512", "1024", "2048",
+}
+
+local TILE_COLORS = {
+    [2] = rgb(238, 228, 218),
+    [4] = rgb(237, 224, 200),
+    [8] = rgb(242, 177, 121),
+    [16] = rgb(245, 149, 99),
+    [32] = rgb(246, 124, 95),
+    [64] = rgb(246, 94, 59),
+    [128] = rgb(237, 207, 114),
+    [256] = rgb(237, 204, 97),
+    [512] = rgb(237, 200, 80),
+    [1024] = rgb(237, 197, 63),
+    [2048] = rgb(237, 194, 46),
+}
+
+local DARK_TEXT = rgb(91, 84, 77)
+
+local board = {}
+local score = 0
+local best = 0
+local game_over = false
+local won = false
+local touch_down = nil
+
+math.randomseed((os.time() or 1) + width * 17 + height * 31 + now_ms())
+
+local function empty_board()
+    board = {}
+    for y = 1, 4 do
+        board[y] = {}
+        for x = 1, 4 do
+            board[y][x] = 0
+        end
+    end
+end
+
+local function tile_xy(x, y)
+    return board_x + gap + (x - 1) * (cell + gap), board_y + gap + (y - 1) * (cell + gap)
+end
+
+local function random_empty_cells(b)
+    local cells = {}
+    for y = 1, 4 do
+        for x = 1, 4 do
+            if b[y][x] == 0 then
+                cells[#cells + 1] = { x = x, y = y }
+            end
+        end
+    end
+    return cells
+end
+
+local function add_random_tile()
+    local cells = random_empty_cells(board)
+    if #cells == 0 then return false end
+    local pick = cells[math.random(1, #cells)]
+    board[pick.y][pick.x] = math.random(1, 10) == 10 and 4 or 2
+    return true
+end
+
+local function has_moves()
+    if #random_empty_cells(board) > 0 then return true end
+    for y = 1, 4 do
+        for x = 1, 4 do
+            local v = board[y][x]
+            if x < 4 and board[y][x + 1] == v then return true end
+            if y < 4 and board[y + 1][x] == v then return true end
+        end
+    end
+    return false
+end
+
+local function reset_game()
+    empty_board()
+    score = 0
+    game_over = false
+    won = false
+    add_random_tile()
+    add_random_tile()
+    request_sfx("start")
+end
+
+local function copy_empty()
+    local b = {}
+    for y = 1, 4 do
+        b[y] = { 0, 0, 0, 0 }
+    end
+    return b
+end
+
+local function coords_for(direction, line)
+    local coords = {}
+    for i = 1, 4 do
+        local x, y
+        if direction == "left" then
+            x, y = i, line
+        elseif direction == "right" then
+            x, y = 5 - i, line
+        elseif direction == "up" then
+            x, y = line, i
+        else
+            x, y = line, 5 - i
+        end
+        coords[i] = { x = x, y = y }
+    end
+    return coords
+end
+
+local function slide(direction)
+    local next_board = copy_empty()
+    local movements = {}
+    local moved = false
+    local merged = false
+
+    for line = 1, 4 do
+        local coords = coords_for(direction, line)
+        local target_i = 1
+        local last_target = nil
+        local target_merged = { false, false, false, false }
+
+        for scan_i = 1, 4 do
+            local src = coords[scan_i]
+            local value = board[src.y][src.x]
+            if value ~= 0 then
+                if last_target and next_board[last_target.y][last_target.x] == value and not target_merged[target_i - 1] then
+                    next_board[last_target.y][last_target.x] = value * 2
+                    target_merged[target_i - 1] = true
+                    score = score + value * 2
+                    if score > best then best = score end
+                    if value * 2 >= 2048 then won = true end
+                    movements[#movements + 1] = {
+                        from_x = src.x, from_y = src.y,
+                        to_x = last_target.x, to_y = last_target.y,
+                        value = value, merge = true,
+                    }
+                    moved = moved or src.x ~= last_target.x or src.y ~= last_target.y
+                    merged = true
+                else
+                    local dst = coords[target_i]
+                    next_board[dst.y][dst.x] = value
+                    last_target = dst
+                    movements[#movements + 1] = {
+                        from_x = src.x, from_y = src.y,
+                        to_x = dst.x, to_y = dst.y,
+                        value = value, merge = false,
+                    }
+                    moved = moved or src.x ~= dst.x or src.y ~= dst.y
+                    target_i = target_i + 1
+                end
+            end
+        end
+    end
+
+    if not moved and not merged then
+        request_sfx("block")
+        return false, {}, false
+    end
+
+    board = next_board
+    return true, movements, merged
+end
+
+local function tile_color(value)
+    return TILE_COLORS[value] or rgb(58, 138, 205)
+end
+
+local function tile_text_color(value)
+    if value <= 4 then return DARK_TEXT end
+    return TEXT
+end
+
+local function draw_bold_text_aligned(x, y, w, h, text, style)
+    display.draw_text_aligned(x, y, w, h, text, style)
+    display.draw_text_aligned(x + 1, y, w, h, text, {
+        color = style.color,
+        font_size = style.font_size,
+        align = style.align,
+        valign = style.valign,
+    })
+end
+
+local function draw_bold_text(x, y, text, style)
+    display.draw_text(x, y, text, style)
+    display.draw_text(x + 1, y, text, {
+        color = style.color,
+        font_size = style.font_size,
+    })
+end
+
+local function draw_number_background()
+    local function draw_layer(zone_x, zone_w, spacing, sizes, salt)
+        if zone_w < 24 then return end
+        local cols = math.ceil(zone_w / spacing) + 1
+        local rows = math.ceil(height / spacing) + 1
+        for row = 0, rows - 1 do
+            for col = 0, cols - 1 do
+                local i = row * cols + col + 1
+                local value = GHOST_VALUES[1 + ((i * 7 + col * 5 + row * 3 + salt) % #GHOST_VALUES)]
+                local font_size = sizes[1 + ((i * 5 + row * 3 + salt) % #sizes)]
+                if #value >= 4 then
+                    font_size = math.min(font_size, 16)
+                elseif #value == 3 then
+                    font_size = math.min(font_size, 20)
+                end
+                local text_w = math.max(font_size, math.floor(font_size * 0.55 * #value))
+                local jitter_x = ((row * 11 + col * 7 + salt) % math.max(3, math.floor(spacing * 0.54)))
+                    - math.floor(spacing * 0.27)
+                local jitter_y = ((row * 5 + col * 13 + salt) % math.max(3, math.floor(spacing * 0.46)))
+                    - math.floor(spacing * 0.23)
+                local x = zone_x + col * spacing + jitter_x - math.floor(text_w * 0.18)
+                local y = row * spacing + jitter_y - math.floor(font_size * 0.18)
+                if x < zone_x + zone_w and x + text_w > zone_x then
+                    draw_bold_text(x, y, value, {
+                        color = GHOST_COLORS[1 + ((i + row + salt) % #GHOST_COLORS)],
+                        font_size = font_size,
+                    })
+                end
+            end
+        end
+    end
+
+    local left_w = sx
+    local right_x = sx + stage
+    local right_w = width - right_x
+    draw_layer(0, left_w, 62, { 28, 32, 36, 40, 44, 48 }, 3)
+    draw_layer(0, left_w, 40, { 12, 16, 20, 24, 28 }, 11)
+    draw_layer(right_x, right_w, 62, { 28, 32, 36, 40, 44, 48 }, 7)
+    draw_layer(right_x, right_w, 40, { 12, 16, 20, 24, 28 }, 17)
+end
+
+local function draw_tile_at(px, py, value, scale)
+    if value == 0 then return end
+    scale = scale or 1
+    local size = math.floor(cell * scale)
+    local ox = math.floor((cell - size) / 2)
+    local x = px + ox
+    local y = py + ox
+    local radius = math.max(4, math.floor(size * 0.08))
+    local font_size = cell >= 78 and 32 or (cell >= 62 and 28 or (cell >= 46 and 24 or 20))
+    if value >= 1024 then
+        font_size = cell >= 72 and 24 or (cell >= 46 and 16 or 12)
+    elseif value >= 128 then
+        font_size = cell >= 72 and 28 or (cell >= 46 and 20 or 16)
+    end
+    display.fill_round_rect(x, y, size, size, radius, tile_color(value))
+    draw_bold_text_aligned(x, y, size, size, tostring(value), {
+        color = tile_text_color(value),
+        font_size = font_size,
+        align = "center",
+        valign = "middle",
+        bg = tile_color(value),
+    })
+end
+
+local function draw_stage()
+    display.clear(BG)
+    draw_number_background()
+    if sx > 0 or sy > 0 then
+        display.fill_round_rect(sx, sy, stage, stage, 0, STAGE_BG)
+    end
+    if sx > 0 then
+        display.fill_rect(sx - 2, sy, 5, stage, SEPARATOR)
+        display.fill_rect(sx + stage, sy, 5, stage, SEPARATOR)
+    end
+
+    local compact = stage < 360
+    local score_w = compact and 52 or clamp(math.floor(stage * 0.17), 68, 88)
+    local score_h = compact and 44 or clamp(math.floor(stage * 0.115), 46, 56)
+    local score_gap = compact and 4 or math.max(6, math.floor(stage * 0.015))
+    local score_y = sy + (compact and 8 or 16)
+    local title_w = compact and 48 or clamp(math.floor(board_size * 0.20), 68, 82)
+    local title_color = TILE_COLORS[2048]
+    display.fill_round_rect(board_x, score_y, title_w, score_h, 5, title_color)
+    draw_bold_text_aligned(board_x, score_y, title_w, score_h, "2048", {
+        color = TEXT,
+        font_size = compact and 16 or 24,
+        align = "center",
+        valign = "middle",
+        bg = title_color,
+    })
+
+    local score_x = board_x + board_size - score_w * 2 - score_gap
+    display.fill_round_rect(score_x, score_y, score_w, score_h, 5, PANEL)
+    display.draw_text_aligned(score_x, score_y + 3, score_w, math.floor(score_h * 0.36), "SCORE", {
+        color = SUBTEXT,
+        font_size = 12,
+        align = "center",
+        valign = "middle",
+        bg = PANEL,
+    })
+    display.draw_text_aligned(score_x, score_y + math.floor(score_h * 0.34), score_w,
+        math.floor(score_h * 0.58), tostring(score), {
+        color = TEXT,
+        font_size = compact and 16 or 20,
+        align = "center",
+        valign = "middle",
+        bg = PANEL,
+    })
+
+    local best_x = score_x + score_w + score_gap
+    display.fill_round_rect(best_x, score_y, score_w, score_h, 5, PANEL)
+    display.draw_text_aligned(best_x, score_y + 3, score_w, math.floor(score_h * 0.36), "BEST", {
+        color = SUBTEXT,
+        font_size = 12,
+        align = "center",
+        valign = "middle",
+        bg = PANEL,
+    })
+    display.draw_text_aligned(best_x, score_y + math.floor(score_h * 0.34), score_w,
+        math.floor(score_h * 0.58), tostring(best), {
+        color = TEXT,
+        font_size = compact and 16 or 20,
+        align = "center",
+        valign = "middle",
+        bg = PANEL,
+    })
+
+    display.fill_round_rect(board_x + 3, board_y + 4, board_size, board_size, 10, BOARD_SHADOW)
+    display.fill_round_rect(board_x, board_y, board_size, board_size, 10, GRID)
+    for y = 1, 4 do
+        for x = 1, 4 do
+            local px, py = tile_xy(x, y)
+            display.fill_round_rect(px, py, cell, cell, 7, EMPTY)
+        end
+    end
+end
+
+local function draw_board(skip_dest)
+    for y = 1, 4 do
+        for x = 1, 4 do
+            if not (skip_dest and skip_dest[y] and skip_dest[y][x]) then
+                local px, py = tile_xy(x, y)
+                draw_tile_at(px, py, board[y][x], 1)
+            end
+        end
+    end
+end
+
+local function draw_overlay()
+    if not game_over and not won then return end
+    local title = game_over and "GAME OVER" or "2048!"
+    local sub = game_over and "swipe to restart" or "keep going"
+    local panel_w = math.floor(board_size * 0.72)
+    local panel_h = 104
+    local x = board_x + math.floor((board_size - panel_w) / 2)
+    local y = board_y + math.floor((board_size - panel_h) / 2)
+    local c = game_over and RED or GOLD
+    display.fill_round_rect(x, y, panel_w, panel_h, 10, STAGE_BG)
+    display.draw_round_rect(x, y, panel_w, panel_h, 10, c)
+    draw_bold_text_aligned(x, y + 18, panel_w, 34, title, {
+        color = c,
+        font_size = 28,
+        align = "center",
+        valign = "middle",
+        bg = STAGE_BG,
+    })
+    draw_bold_text_aligned(x, y + 58, panel_w, 24, sub, {
+        color = TITLE_TEXT,
+        font_size = 16,
+        align = "center",
+        valign = "middle",
+        bg = STAGE_BG,
+    })
+end
+
+local function render()
+    display.begin_frame({ clear = true, color = BG })
+    draw_stage()
+    draw_board(nil)
+    draw_overlay()
+    display.present()
+    display.end_frame()
+end
+
+local function finish_move(merged)
+    add_random_tile()
+    if not has_moves() then
+        game_over = true
+        request_sfx("over")
+    elseif merged then
+        request_sfx("merge")
+    else
+        request_sfx("move")
+    end
+end
+
+local function direction_from_swipe(dx, dy)
+    if math.abs(dx) < SWIPE_THRESHOLD and math.abs(dy) < SWIPE_THRESHOLD then
+        return nil
+    end
+    if math.abs(dx) > math.abs(dy) then
+        return dx > 0 and "right" or "left"
+    end
+    return dy > 0 and "down" or "up"
+end
+
+local function handle_touch()
+    local polled, info = pcall(lcd_touch.poll, touch_handle)
+    if not polled then
+        print("[game_2048] ERROR: lcd_touch.poll failed: " .. tostring(info))
+        return nil
+    end
+
+    if info.pressed then
+        if not touch_down then
+            touch_down = { x = info.x, y = info.y }
+        end
+        return false
+    elseif info.just_released then
+        if touch_down then
+            local direction = direction_from_swipe(info.x - touch_down.x, info.y - touch_down.y)
+            touch_down = nil
+            return direction or false
+        end
+        touch_down = nil
+    end
+
+    return false
+end
+
+reset_game()
+render()
+print(string.format("[game_2048] ready screen=%dx%d stage=%dx%d run_ms=%d", width, height, stage, stage, RUN_TIME_MS))
+print("[game_2048] swipe on the LCD to slide tiles")
+
+local run_ok, run_err = xpcall(function()
+    local start = now_ms()
+    while now_ms() - start < RUN_TIME_MS do
+        drain_sfx()
+        local direction = handle_touch()
+        if direction == nil then break end
+        if direction then
+            if game_over then
+                reset_game()
+            else
+                local moved, _, merged = slide(direction)
+                if moved then
+                    finish_move(merged)
+                elseif not has_moves() then
+                    game_over = true
+                    request_sfx("over")
+                end
+            end
+            render()
+        end
+        delay.delay_ms(FRAME_MS)
+    end
+end, debug.traceback)
+
+cleanup()
+if not run_ok then
+    print("[game_2048] ERROR: " .. tostring(run_err))
+end
+print("[game_2048] done")

--- a/skills/number_puzzle/SKILL.md
+++ b/skills/number_puzzle/SKILL.md
@@ -1,0 +1,59 @@
+---
+{
+  "name": "number_puzzle",
+  "description": "Play a touch-controlled 15-puzzle number sliding game on the LCD with lightweight rendering, swipe controls, and pixel-style sound effects.",
+  "author": "ESP-Claw contributor",
+  "metadata": {
+    "category": ["game", "ui"],
+    "tags": ["15-puzzle", "number puzzle", "sliding puzzle", "touch", "animation", "sound"],
+    "peripherals": ["display"],
+    "cap_groups": ["cap_lua"],
+    "manage_mode": "web"
+  },
+  "simulator": {
+    "entry": "scripts/number_puzzle.lua",
+    "files": [
+      "scripts/number_puzzle.lua"
+    ]
+  }
+}
+---
+
+# Number Puzzle
+
+Use this skill when the user asks to play 数字华容道, number puzzle, 15-puzzle, sliding puzzle, or a tile ordering game.
+
+The Lua script renders a 4x4 board with tiles 1-15 and one empty space. Tap a numbered tile next to the empty space, or swipe up/down/left/right to slide the matching adjacent tile into the empty space. The goal is to restore the board to 1-15 with the empty space at bottom right. Normal moves use partial refresh for the changed cells and header info.
+
+## Requirements
+
+- A display device declared as `display_lcd` in board hardware info.
+- LCD touch input declared as `lcd_touch`.
+- Audio output is optional and used for pixel-style move, blocked, shuffle, and win sound effects.
+
+## Tool Call Inputs
+
+```json
+{
+  "path": "{CUR_SKILL_DIR}/scripts/number_puzzle.lua",
+  "args": {}
+}
+```
+
+Optional args:
+
+| Arg | Default | Meaning |
+|-----|---------|---------|
+| `run_time_ms` | `600000` | Game duration in milliseconds |
+| `sample_rate_hz` | board `audio_dac` rate | Output sample rate for sound effects |
+| `target_size` | `480` | Square game stage size when screen space allows |
+| `shuffle_steps` | `140` | Number of legal random moves used to create a solvable puzzle |
+| `perf_log` | `1` | Set to `0` to disable timing logs for startup, touch handling, rendering, and actions |
+
+## Behavior
+
+Tap an adjacent tile to slide it into the empty space, or swipe in the direction the tile should move. For example, left swipe moves the tile on the right side of the empty space left into the empty space. The board is shuffled only through legal moves, so every puzzle is solvable. When solved, the script shows a completion panel with move count and elapsed time.
+
+## Files
+
+- `scripts/number_puzzle.lua`

--- a/skills/number_puzzle/scripts/number_puzzle.lua
+++ b/skills/number_puzzle/scripts/number_puzzle.lua
@@ -1,0 +1,719 @@
+local bm = require("board_manager")
+local display = require("display")
+local delay = require("delay")
+local system_ok, system = pcall(require, "system")
+local touch_ok, lcd_touch = pcall(require, "lcd_touch")
+local audio_ok, audio = pcall(require, "audio")
+
+local a = type(args) == "table" and args or {}
+
+local function int_arg(name, default)
+    local value = a[name]
+    if type(value) == "number" then
+        return math.floor(value)
+    end
+    return default
+end
+
+local function now_ms()
+    if system_ok and system and system.millis then
+        return system.millis()
+    end
+    return math.floor(os.clock() * 1000)
+end
+
+local function rgb(r, g, b)
+    return { r = r, g = g, b = b }
+end
+
+local function clamp(v, lo, hi)
+    if v < lo then return lo end
+    if v > hi then return hi end
+    return v
+end
+
+local RUN_TIME_MS = int_arg("run_time_ms", 600000)
+local TARGET_SIZE = clamp(int_arg("target_size", 480), 240, 800)
+local SHUFFLE_STEPS = clamp(int_arg("shuffle_steps", 140), 20, 800)
+local PERF_LOG = int_arg("perf_log", 1) ~= 0
+local FRAME_MS = 16
+local TAP_SLOP = 18
+local SWIPE_THRESHOLD = 44
+local SOUND_VOLUME = 84
+local UAC_FLUSH_PCM_BYTES = 4000
+
+local function log_perf(label, message)
+    if PERF_LOG then
+        print("[number_puzzle][perf] " .. label .. " " .. message)
+    end
+end
+
+local output_codec, board_output_rate, output_channels, output_bits =
+    bm.get_audio_codec_output_params("audio_dac")
+local OUTPUT_SAMPLE_RATE = int_arg("sample_rate_hz", board_output_rate or 16000)
+
+local panel, io, width, height, panel_if = bm.get_display_lcd_params("display_lcd")
+if not panel then
+    print("[number_puzzle] ERROR: get_display_lcd_params(display_lcd) failed: " .. tostring(io))
+    return
+end
+
+local ok, err = pcall(display.init, panel, io, width, height, panel_if)
+if not ok then
+    print("[number_puzzle] ERROR: display.init failed: " .. tostring(err))
+    return
+end
+
+local screen_ready = true
+width = display.width
+height = display.height
+
+local touch_handle = nil
+local audio_output = nil
+local sfx = {}
+local pending_sfx = nil
+
+local function cleanup()
+    if audio_output then
+        pcall(audio_output.close, audio_output)
+        audio_output = nil
+    end
+    if screen_ready then
+        pcall(display.end_frame)
+        pcall(display.deinit)
+        screen_ready = false
+    end
+end
+
+if width <= 0 or height <= 0 then
+    print("[number_puzzle] ERROR: invalid display size")
+    cleanup()
+    return
+end
+
+if not touch_ok then
+    print("[number_puzzle] ERROR: require(lcd_touch) failed")
+    cleanup()
+    return
+end
+
+local touch_err
+touch_handle, touch_err = bm.get_lcd_touch_handle("lcd_touch")
+if not touch_handle then
+    print("[number_puzzle] ERROR: get_lcd_touch_handle(lcd_touch) failed: " .. tostring(touch_err))
+    cleanup()
+    return
+end
+
+local synced, sync_err = pcall(lcd_touch.sync, touch_handle)
+if not synced then
+    print("[number_puzzle] ERROR: lcd_touch.sync failed: " .. tostring(sync_err))
+    cleanup()
+    return
+end
+
+local function build_tone(freq_hz, duration_ms, amp)
+    local rate = OUTPUT_SAMPLE_RATE
+    local frames = math.floor(rate * duration_ms / 1000)
+    if frames <= 0 then
+        return string.rep("\0", UAC_FLUSH_PCM_BYTES)
+    end
+
+    local chunks = {}
+    local phase = 0
+    local step = 2 * math.pi * freq_hz / rate
+    for i = 1, frames do
+        local raw = math.sin(phase) >= 0 and 1 or -1
+        local fade = 1
+        if i > frames * 0.68 then
+            fade = (frames - i) / math.max(1, frames * 0.32)
+        end
+        local sample = math.floor(raw * amp * fade)
+        phase = phase + step
+        if sample > 32767 then sample = 32767 end
+        if sample < -32768 then sample = -32768 end
+        local u = sample < 0 and sample + 65536 or sample
+        chunks[i] = string.char(u % 256, math.floor(u / 256) % 256)
+    end
+
+    local pcm = table.concat(chunks)
+    if #pcm < UAC_FLUSH_PCM_BYTES then
+        pcm = pcm .. string.rep("\0", UAC_FLUSH_PCM_BYTES - #pcm)
+    end
+    return pcm
+end
+
+local function init_audio()
+    if not audio_ok or not output_codec then
+        print("[number_puzzle] WARN: audio unavailable")
+        return
+    end
+
+    local out_ok, out = pcall(function()
+        return audio.new_output({
+            codec = output_codec,
+            sample_rate = OUTPUT_SAMPLE_RATE,
+            channels = output_channels,
+            bits = output_bits,
+            volume = SOUND_VOLUME,
+        })
+    end)
+    if not out_ok or not out then
+        print("[number_puzzle] WARN: audio init failed: " .. tostring(out))
+        return
+    end
+
+    audio_output = out
+    sfx.shuffle = build_tone(620, 90, 12000)
+    sfx.move = build_tone(380, 50, 9000)
+    sfx.block = build_tone(150, 75, 8500)
+    sfx.win = build_tone(1040, 220, 13000)
+    pending_sfx = sfx.shuffle
+end
+
+local function request_sfx(name)
+    if sfx[name] then
+        pending_sfx = sfx[name]
+    end
+end
+
+local function drain_sfx()
+    if not pending_sfx or not audio_output then
+        return false, 0
+    end
+    local t0 = now_ms()
+    local pcm = pending_sfx
+    local wrote, write_err = audio_output:write(pcm)
+    if wrote or (write_err and not tostring(write_err):find("busy", 1, true)) then
+        pending_sfx = nil
+    end
+    return true, now_ms() - t0
+end
+
+init_audio()
+
+local stage = math.min(TARGET_SIZE, width, height)
+local sx = math.floor((width - stage) / 2)
+local sy = math.floor((height - stage) / 2)
+local margin = math.max(14, math.floor(stage * 0.05))
+local header_h = math.max(70, math.floor(stage * 0.17))
+local gap = math.max(6, math.floor(stage * 0.018))
+local board_size = stage - margin * 2 - header_h
+board_size = board_size - (board_size % 4)
+local cell = math.floor((board_size - gap * 5) / 4)
+board_size = cell * 4 + gap * 5
+local board_x = sx + math.floor((stage - board_size) / 2)
+local board_y = sy + header_h + math.floor((stage - header_h - board_size) / 2)
+local compact_header = stage < 480
+local toolbar_gap = compact_header and 5 or 7
+local new_w = compact_header and 58 or 68
+local new_h = compact_header and 26 or 54
+local time_w = compact_header and 72 or 84
+local moves_w = compact_header and 68 or 80
+local new_x = sx + stage - margin - new_w
+local new_y = compact_header and sy + 40 or sy + 9
+local time_x = new_x - toolbar_gap - time_w
+local moves_x = time_x - toolbar_gap - moves_w
+
+local BG = rgb(54, 34, 20)
+local STAGE_BG = rgb(104, 67, 36)
+local PANEL = rgb(126, 82, 42)
+local GRID = rgb(96, 57, 28)
+local EMPTY = rgb(72, 43, 24)
+local TILE = rgb(224, 162, 82)
+local TILE_DARK = rgb(132, 78, 34)
+local TILE_ALT = rgb(239, 185, 104)
+local TILE_ALT_DARK = rgb(150, 92, 38)
+local TEXT = rgb(255, 239, 203)
+local DARK_TEXT = rgb(57, 34, 20)
+local SUBTEXT = rgb(244, 203, 144)
+local GREEN = rgb(129, 194, 102)
+local RED = rgb(191, 75, 56)
+local FRAME_LINE = rgb(246, 189, 105)
+local SHADOW = rgb(38, 22, 13)
+
+local board = {}
+local empty_x = 4
+local empty_y = 4
+local moves = 0
+local best_moves = 0
+local start_ms = now_ms()
+local run_start_ms = now_ms()
+local won = false
+local touch_down = nil
+
+math.randomseed((os.time() or 1) + width * 19 + height * 23 + now_ms())
+
+local function set_solved()
+    local n = 1
+    board = {}
+    for y = 1, 4 do
+        board[y] = {}
+        for x = 1, 4 do
+            if x == 4 and y == 4 then
+                board[y][x] = 0
+            else
+                board[y][x] = n
+                n = n + 1
+            end
+        end
+    end
+    empty_x = 4
+    empty_y = 4
+end
+
+local function is_solved()
+    local n = 1
+    for y = 1, 4 do
+        for x = 1, 4 do
+            if x == 4 and y == 4 then
+                if board[y][x] ~= 0 then return false end
+            elseif board[y][x] ~= n then
+                return false
+            end
+            n = n + 1
+        end
+    end
+    return true
+end
+
+local function tile_xy(x, y)
+    return board_x + gap + (x - 1) * (cell + gap), board_y + gap + (y - 1) * (cell + gap)
+end
+
+local function legal_neighbors()
+    local cells = {}
+    if empty_x > 1 then cells[#cells + 1] = { x = empty_x - 1, y = empty_y } end
+    if empty_x < 4 then cells[#cells + 1] = { x = empty_x + 1, y = empty_y } end
+    if empty_y > 1 then cells[#cells + 1] = { x = empty_x, y = empty_y - 1 } end
+    if empty_y < 4 then cells[#cells + 1] = { x = empty_x, y = empty_y + 1 } end
+    return cells
+end
+
+local function swap_with_empty(x, y)
+    board[empty_y][empty_x] = board[y][x]
+    board[y][x] = 0
+    empty_x = x
+    empty_y = y
+end
+
+local function shuffle_board()
+    local last_x, last_y = nil, nil
+    for _ = 1, SHUFFLE_STEPS do
+        local choices = legal_neighbors()
+        local filtered = {}
+        for _, c in ipairs(choices) do
+            if not (c.x == last_x and c.y == last_y) then
+                filtered[#filtered + 1] = c
+            end
+        end
+        if #filtered > 0 then
+            choices = filtered
+        end
+        local pick = choices[math.random(1, #choices)]
+        last_x, last_y = empty_x, empty_y
+        swap_with_empty(pick.x, pick.y)
+    end
+end
+
+local function new_game()
+    set_solved()
+    repeat
+        shuffle_board()
+    until not is_solved()
+    moves = 0
+    won = false
+    start_ms = now_ms()
+    touch_down = nil
+    request_sfx("shuffle")
+end
+
+local function adjacent_to_empty(x, y)
+    return math.abs(x - empty_x) + math.abs(y - empty_y) == 1
+end
+
+local function elapsed_seconds()
+    return math.max(0, math.floor((now_ms() - start_ms) / 1000))
+end
+
+local function remaining_seconds()
+    return math.max(0, math.ceil((RUN_TIME_MS - (now_ms() - run_start_ms)) / 1000))
+end
+
+local function format_time(sec)
+    local m = math.floor(sec / 60)
+    local s = sec % 60
+    return string.format("%02d:%02d", m, s)
+end
+
+local function tile_at_point(px, py)
+    if px >= new_x and px <= new_x + new_w and py >= new_y and py <= new_y + new_h then
+        return "new"
+    end
+    if px < board_x or py < board_y or px >= board_x + board_size or py >= board_y + board_size then
+        return nil
+    end
+    local rel_x = px - board_x
+    local rel_y = py - board_y
+    local x = math.floor(rel_x / (cell + gap)) + 1
+    local y = math.floor(rel_y / (cell + gap)) + 1
+    if x < 1 or x > 4 or y < 1 or y > 4 then return nil end
+    local inner_x = rel_x - (x - 1) * (cell + gap)
+    local inner_y = rel_y - (y - 1) * (cell + gap)
+    if inner_x < gap or inner_y < gap then return nil end
+    if board[y][x] == 0 then return nil end
+    return { x = x, y = y }
+end
+
+local function direction_from_swipe(dx, dy)
+    if math.abs(dx) < SWIPE_THRESHOLD and math.abs(dy) < SWIPE_THRESHOLD then
+        return nil
+    end
+    if math.abs(dx) > math.abs(dy) then
+        return dx > 0 and "right" or "left"
+    end
+    return dy > 0 and "down" or "up"
+end
+
+local function tile_for_swipe(direction)
+    local x = empty_x
+    local y = empty_y
+    if direction == "left" then
+        x = empty_x + 1
+    elseif direction == "right" then
+        x = empty_x - 1
+    elseif direction == "up" then
+        y = empty_y + 1
+    elseif direction == "down" then
+        y = empty_y - 1
+    end
+    if x < 1 or x > 4 or y < 1 or y > 4 then
+        return { blocked = true }
+    end
+    return { x = x, y = y }
+end
+
+local function draw_tile_at(px, py, value)
+    if value == 0 then return end
+    local color = (value % 2 == 0) and TILE or TILE_ALT
+    local border = (value % 2 == 0) and TILE_DARK or TILE_ALT_DARK
+    display.fill_rect(px + 2, py + 3, cell, cell, SHADOW)
+    display.fill_rect(px, py, cell, cell, color)
+    display.draw_rect(px, py, cell, cell, border)
+    display.fill_rect(px + 5, py + 6, cell - 10, 2, rgb(255, 214, 137))
+    display.draw_text_aligned(px, py, cell, cell, tostring(value), {
+        color = DARK_TEXT,
+        font_size = value >= 10 and 27 or 31,
+        align = "center",
+        valign = "middle",
+        bg = color,
+    })
+end
+
+local function draw_empty_cell(x, y)
+    local px, py = tile_xy(x, y)
+    display.fill_rect(px + 2, py + 3, cell, cell, GRID)
+    display.fill_rect(px, py, cell, cell, EMPTY)
+    display.draw_rect(px, py, cell, cell, rgb(115, 68, 32))
+end
+
+local function draw_cell(x, y)
+    local px, py = tile_xy(x, y)
+    draw_empty_cell(x, y)
+    draw_tile_at(px, py, board[y][x])
+end
+
+local function draw_info()
+    local font_size = compact_header and 12 or 13
+    display.fill_rect(moves_x, new_y, moves_w, new_h, GRID)
+    display.draw_rect(moves_x, new_y, moves_w, new_h, PANEL)
+    display.fill_rect(time_x, new_y, time_w, new_h, GRID)
+    display.draw_rect(time_x, new_y, time_w, new_h, PANEL)
+    if compact_header then
+        display.draw_text_aligned(moves_x, new_y, moves_w, new_h, "MOVES " .. tostring(moves), {
+            color = TEXT, font_size = font_size, align = "center", valign = "middle", bg = GRID,
+        })
+        display.draw_text_aligned(time_x, new_y, time_w, new_h, "TIME " .. format_time(remaining_seconds()), {
+            color = TEXT, font_size = font_size, align = "center", valign = "middle", bg = GRID,
+        })
+    else
+        local label_h = 22
+        display.draw_text_aligned(moves_x, new_y + 2, moves_w, label_h, "MOVES", {
+            color = TEXT, font_size = 12, align = "center", valign = "middle", bg = GRID,
+        })
+        display.draw_text_aligned(moves_x, new_y + label_h - 1, moves_w, new_h - label_h, tostring(moves), {
+            color = FRAME_LINE, font_size = 19, align = "center", valign = "middle", bg = GRID,
+        })
+        display.draw_text_aligned(time_x, new_y + 2, time_w, label_h, "TIME", {
+            color = TEXT, font_size = 12, align = "center", valign = "middle", bg = GRID,
+        })
+        display.draw_text_aligned(time_x, new_y + label_h - 1, time_w, new_h - label_h,
+            format_time(remaining_seconds()), {
+            color = FRAME_LINE, font_size = 16, align = "center", valign = "middle", bg = GRID,
+        })
+    end
+end
+
+local function draw_stage()
+    display.clear(BG)
+    display.fill_rect(sx, sy, stage, stage, STAGE_BG)
+    display.draw_rect(sx, sy, stage, stage, FRAME_LINE)
+    local title_x = sx + margin
+    local title_y = compact_header and sy + 5 or sy + 9
+    local title_w = compact_header and 106 or math.min(120, moves_x - title_x - toolbar_gap)
+    local title_h = compact_header and 32 or 54
+    display.fill_round_rect(title_x, title_y, title_w, title_h, 6, PANEL)
+    display.draw_round_rect(title_x, title_y, title_w, title_h, 6, FRAME_LINE)
+    display.draw_text_aligned(title_x, title_y + 2, title_w, math.floor(title_h / 2), "Number", {
+        color = TEXT,
+        font_size = compact_header and 14 or 18,
+        align = "center",
+        valign = "middle",
+        bg = PANEL,
+    })
+    display.draw_text_aligned(title_x, title_y + math.floor(title_h / 2) - 2,
+        title_w, math.ceil(title_h / 2), "Puzzle", {
+        color = SUBTEXT,
+        font_size = compact_header and 14 or 18,
+        align = "center",
+        valign = "middle",
+        bg = PANEL,
+    })
+
+    display.fill_rect(new_x + 2, new_y + 3, new_w, new_h, SHADOW)
+    display.fill_rect(new_x, new_y, new_w, new_h, TILE_ALT)
+    display.draw_rect(new_x, new_y, new_w, new_h, TILE_ALT_DARK)
+    display.draw_text_aligned(new_x, new_y, new_w, new_h, "NEW", {
+        color = DARK_TEXT,
+        font_size = compact_header and 14 or 16,
+        align = "center",
+        valign = "middle",
+        bg = TILE_ALT,
+    })
+
+    draw_info()
+
+    display.fill_rect(board_x + 4, board_y + 5, board_size, board_size, SHADOW)
+    display.fill_rect(board_x, board_y, board_size, board_size, GRID)
+    display.draw_rect(board_x, board_y, board_size, board_size, FRAME_LINE)
+    for y = 1, 4 do
+        for x = 1, 4 do
+            draw_empty_cell(x, y)
+        end
+    end
+end
+
+local function draw_board(skip_x, skip_y)
+    for y = 1, 4 do
+        for x = 1, 4 do
+            if not (x == skip_x and y == skip_y) then
+                local px, py = tile_xy(x, y)
+                draw_tile_at(px, py, board[y][x])
+            end
+        end
+    end
+end
+
+local function draw_overlay()
+    if not won then return end
+    local panel_w = math.floor(board_size * 0.76)
+    local panel_h = 118
+    local x = board_x + math.floor((board_size - panel_w) / 2)
+    local y = board_y + math.floor((board_size - panel_h) / 2)
+    display.fill_round_rect(x + 4, y + 5, panel_w, panel_h, 10, SHADOW)
+    display.fill_round_rect(x, y, panel_w, panel_h, 10, rgb(86, 53, 29))
+    display.draw_round_rect(x, y, panel_w, panel_h, 10, GREEN)
+    display.draw_text_aligned(x, y + 15, panel_w, 34, "SOLVED!", {
+        color = GREEN,
+        font_size = 28,
+        align = "center",
+        valign = "middle",
+        bg = rgb(21, 25, 32),
+    })
+    display.draw_text_aligned(x, y + 55, panel_w, 24, "moves " .. tostring(moves) .. "   " .. format_time(elapsed_seconds()), {
+        color = TEXT,
+        font_size = 16,
+        align = "center",
+        valign = "middle",
+        bg = rgb(21, 25, 32),
+    })
+    display.draw_text_aligned(x, y + 82, panel_w, 22, "tap NEW to shuffle", {
+        color = SUBTEXT,
+        font_size = 14,
+        align = "center",
+        valign = "middle",
+        bg = rgb(21, 25, 32),
+    })
+end
+
+local function render()
+    local t0 = now_ms()
+    display.begin_frame({ clear = true, color = BG })
+    draw_stage()
+    draw_board(nil, nil)
+    draw_overlay()
+    display.present()
+    display.end_frame()
+    return now_ms() - t0
+end
+
+local function render_partial(change)
+    local t0 = now_ms()
+    display.begin_frame({ clear = false })
+    if change and change.moved then
+        draw_cell(change.from_x, change.from_y)
+        draw_cell(change.to_x, change.to_y)
+    end
+    draw_info()
+    if won then
+        draw_overlay()
+    end
+    display.present()
+    display.end_frame()
+    return now_ms() - t0
+end
+
+local function render_partial_clock()
+    local t0 = now_ms()
+    display.begin_frame({ clear = false })
+    draw_info()
+    display.present()
+    display.end_frame()
+    return now_ms() - t0
+end
+
+local function move_tile(x, y)
+    if won then
+        request_sfx("block")
+        return { blocked = true }
+    end
+    if not adjacent_to_empty(x, y) then
+        request_sfx("block")
+        return { blocked = true }
+    end
+
+    local value = board[y][x]
+    local old_empty_x, old_empty_y = empty_x, empty_y
+    board[y][x] = 0
+    board[old_empty_y][old_empty_x] = value
+    empty_x = x
+    empty_y = y
+    moves = moves + 1
+    request_sfx("move")
+
+    if is_solved() then
+        won = true
+        if best_moves == 0 or moves < best_moves then
+            best_moves = moves
+        end
+        request_sfx("win")
+    end
+
+    return {
+        moved = true,
+        from_x = x,
+        from_y = y,
+        to_x = old_empty_x,
+        to_y = old_empty_y,
+    }
+end
+
+local function handle_touch()
+    local polled, info = pcall(lcd_touch.poll, touch_handle)
+    if not polled then
+        print("[number_puzzle] ERROR: lcd_touch.poll failed: " .. tostring(info))
+        return nil
+    end
+
+    if info.pressed then
+        if not touch_down then
+            touch_down = { x = info.x, y = info.y }
+        end
+        return false
+    elseif info.just_released then
+        if not touch_down then
+            return false
+        end
+        local dx = info.x - touch_down.x
+        local dy = info.y - touch_down.y
+        local released_x = info.x
+        local released_y = info.y
+        touch_down = nil
+        local direction = direction_from_swipe(dx, dy)
+        if direction then
+            return tile_for_swipe(direction)
+        end
+        if math.abs(dx) > TAP_SLOP or math.abs(dy) > TAP_SLOP then
+            return false
+        end
+        return tile_at_point(released_x, released_y) or false
+    end
+
+    return false
+end
+
+local init_t0 = now_ms()
+new_game()
+local init_render_ms = render()
+print(string.format("[number_puzzle] ready screen=%dx%d stage=%dx%d shuffle_steps=%d run_ms=%d",
+    width, height, stage, stage, SHUFFLE_STEPS, RUN_TIME_MS))
+print("[number_puzzle] tap a tile adjacent to the blank space, or swipe to move a tile into the blank")
+log_perf("startup", string.format("new_game=%dms render=%dms", now_ms() - init_t0 - init_render_ms, init_render_ms))
+
+local run_ok, run_err = xpcall(function()
+    local last_clock_second = remaining_seconds()
+    while now_ms() - run_start_ms < RUN_TIME_MS do
+        local loop_t0 = now_ms()
+        local sfx_attempted, sfx_ms = drain_sfx()
+        local touch_t0 = now_ms()
+        local action = handle_touch()
+        local touch_ms = now_ms() - touch_t0
+        if action == nil then break end
+        if action then
+            local action_name = "move"
+            local force_full_render = false
+            local change = nil
+            local move_t0 = now_ms()
+            if action == "new" then
+                new_game()
+                action_name = "new"
+                force_full_render = true
+            elseif action.blocked then
+                request_sfx("block")
+                action_name = "blocked"
+            else
+                change = move_tile(action.x, action.y)
+                if change and change.blocked then
+                    action_name = "blocked"
+                end
+            end
+            local move_ms = now_ms() - move_t0
+            local render_ms = force_full_render and render() or render_partial(change)
+            last_clock_second = remaining_seconds()
+            log_perf("action", string.format(
+                "kind=%s touch=%dms move=%dms render=%dms sfx_before=%s/%dms total=%dms",
+                action_name,
+                touch_ms,
+                move_ms,
+                render_ms,
+                tostring(sfx_attempted),
+                sfx_ms,
+                now_ms() - loop_t0
+            ))
+        else
+            local clock_second = remaining_seconds()
+            if clock_second ~= last_clock_second then
+                last_clock_second = clock_second
+                local render_ms = render_partial_clock()
+                log_perf("clock", string.format("touch=%dms render=%dms total=%dms", touch_ms, render_ms, now_ms() - loop_t0))
+            end
+        end
+        delay.delay_ms(FRAME_MS)
+    end
+end, debug.traceback)
+
+cleanup()
+if not run_ok then
+    print("[number_puzzle] ERROR: " .. tostring(run_err))
+end
+print("[number_puzzle] done")

--- a/skills/snake_game/SKILL.md
+++ b/skills/snake_game/SKILL.md
@@ -1,0 +1,58 @@
+---
+{
+  "name": "snake_game",
+  "description": "Play a touch-swipe Snake game with a responsive blue-white cyber interface, data-link boot animation, evolving color trail, and sound effects.",
+  "author": "ESP-Claw contributor",
+  "metadata": {
+    "category": ["game", "ui"],
+    "tags": ["snake", "arcade", "touch", "swipe", "cyber", "sound"],
+    "peripherals": ["display"],
+    "cap_groups": ["cap_lua"],
+    "manage_mode": "web"
+  },
+  "simulator": {
+    "entry": "scripts/snake_game.lua",
+    "files": [
+      "scripts/snake_game.lua"
+    ]
+  }
+}
+---
+
+# Snake Game
+
+Use this skill when the user asks to play Snake, 贪吃蛇, a touch-swipe arcade game, or a classic growing snake game.
+
+The Lua script renders a responsive 15x15 blue-white cyber board on the LCD. A short system-link animation leads to the ready screen; the first swipe launches a falling data-cursor sequence before the grid deploys. Swipe to steer, tap the HUD pause button to pause or resume, and eat food to unlock additional trail colors. The game ends when the snake hits a wall or itself.
+
+## Requirements
+
+- A display device declared as `display_lcd` in board hardware info.
+- LCD touch input declared as `lcd_touch`.
+- Audio output is optional and used for pixel-style start, food, turn, and crash sound effects.
+
+## Tool Call Inputs
+
+```json
+{
+  "path": "{CUR_SKILL_DIR}/scripts/snake_game.lua",
+  "args": {}
+}
+```
+
+Optional args:
+
+| Arg | Default | Meaning |
+|-----|---------|---------|
+| `run_time_ms` | `180000` | Game duration in milliseconds |
+| `sample_rate_hz` | board `audio_dac` rate | Output sample rate for sound effects |
+| `target_size` | `480` | Square game stage size when screen space allows |
+| `grid_size` | `15` | Snake grid width and height |
+
+## Behavior
+
+The snake waits for the first swipe before deploying the board and moving. Swipe to change direction while playing. Tap PAUSE or RESUME in the HUD to control the game state. The snake grows after eating food and speeds up every few points. After game over, one swipe restarts the game in the selected direction.
+
+## Files
+
+- `scripts/snake_game.lua`

--- a/skills/snake_game/scripts/snake_game.lua
+++ b/skills/snake_game/scripts/snake_game.lua
@@ -443,15 +443,24 @@ local function draw_hud()
     else
         display.fill_round_rect(hud_x, hud_y, hud_w, hud_h, 7, PANEL)
         display.draw_round_rect(hud_x, hud_y, hud_w, hud_h, 7, BORDER)
-        local title_w = math.floor(hud_w * 0.30)
+        local title_w = math.floor(hud_w * 0.25)
         display.draw_text_aligned(hud_x + 6, hud_y, title_w, hud_h, "SNAKE", {
             color = CYAN, font_size = title_font, align = "left", valign = "middle", bg = PANEL,
         })
         local stats_x = hud_x + title_w
         local stats_w = pause_x - stats_x - 6
-        local line = string.format("SCORE %d   BEST %d   LV %d", score, best, 1 + math.floor(score / 5))
-        display.draw_text_aligned(stats_x, hud_y, stats_w, hud_h, line, {
-            color = TEXT, font_size = small_font, align = "center", valign = "middle", bg = PANEL,
+        local score_w = math.floor(stats_w * 0.38)
+        local best_w = math.floor(stats_w * 0.36)
+        local level_w = stats_w - score_w - best_w
+        display.draw_text_aligned(stats_x, hud_y, score_w, hud_h, "SCORE " .. tostring(score), {
+            color = TEXT, font_size = small_font, align = "left", valign = "middle", bg = PANEL,
+        })
+        display.draw_text_aligned(stats_x + score_w, hud_y, best_w, hud_h, "BEST " .. tostring(best), {
+            color = TEXT, font_size = small_font, align = "left", valign = "middle", bg = PANEL,
+        })
+        display.draw_text_aligned(stats_x + score_w + best_w, hud_y, level_w, hud_h,
+            "LV " .. tostring(1 + math.floor(score / 5)), {
+            color = CYAN, font_size = small_font, align = "right", valign = "middle", bg = PANEL,
         })
         draw_pause_button()
     end
@@ -573,21 +582,6 @@ local function draw_data_cursor(cx, cy, r, color)
     display.draw_round_rect(cx - r, cy - r, r * 2, r * 2, 2, color)
 end
 
-local function draw_data_glyph(x, y, size, variant, color)
-    if variant == 0 then
-        display.draw_line(x, y - size, x, y + size, color)
-        display.draw_line(x, y - size, x + size, y - size, color)
-        display.draw_line(x, y, x - size, y + size, color)
-    elseif variant == 1 then
-        display.draw_round_rect(x - size, y - size, size * 2, size * 2, 1, color)
-        display.draw_line(x - size, y, x + size, y, color)
-    else
-        display.draw_line(x - size, y - size, x + size, y - size, color)
-        display.draw_line(x + size, y - size, x - size, y + size, color)
-        display.draw_line(x - size, y + size, x + size, y + size, color)
-    end
-end
-
 local function draw_food()
     local cx, cy = cell_center(food.x, food.y)
     local r = math.max(4, math.floor(cell * 0.28))
@@ -643,109 +637,6 @@ local function render(full, refresh_hud)
     display.end_frame()
 end
 
-local function draw_boot_animation()
-    local panel_w = math.min(math.floor(board_size * 0.68), 360)
-    local panel_h = clamp(math.floor(board_size * 0.24), 82, 116)
-    local x = board_x + math.floor((board_size - panel_w) / 2)
-    local y = board_y + math.floor((board_size - panel_h) / 2)
-    local bar_x = x + math.floor(panel_w * 0.12)
-    local bar_y = y + math.floor(panel_h * 0.64)
-    local bar_w = math.floor(panel_w * 0.76)
-    local bar_h = math.max(5, math.floor(panel_h * 0.07))
-
-    for frame = 0, 12 do
-        display.begin_frame({ clear = true, color = BG })
-        draw_background()
-        draw_hud()
-        draw_board_shell()
-        display.fill_round_rect(x, y, panel_w, panel_h, 7, PANEL)
-        display.draw_round_rect(x, y, panel_w, panel_h, 7, BORDER_HI)
-        display.draw_text_aligned(x, y + 8, panel_w, math.floor(panel_h * 0.32), "SYSTEM LINK", {
-            color = TEXT, font_size = stat_font, align = "center", valign = "middle", bg = PANEL,
-        })
-        local dots = string.rep(".", frame % 4)
-        display.draw_text_aligned(x, y + math.floor(panel_h * 0.35), panel_w, math.floor(panel_h * 0.22),
-            "LOADING DATA" .. dots, {
-                color = CYAN, font_size = small_font, align = "center", valign = "middle", bg = PANEL,
-            })
-        display.fill_rect(bar_x, bar_y, bar_w, bar_h, CYAN_DIM)
-        if frame > 0 then
-            display.fill_rect(bar_x, bar_y, math.floor(bar_w * frame / 12), bar_h, CYAN)
-        end
-        display.present()
-        display.end_frame()
-        delay.delay_ms(55)
-    end
-end
-
-local function draw_deploy_animation(start_dir)
-    reset_game(start_dir)
-    phase = "deploying"
-    local stream_count = math.max(GRID_N + 6, math.floor(board_size / math.max(10, cell * 0.58)))
-    local stream_gap = board_size / stream_count
-    local glyph_size = math.max(2, math.floor(cell * 0.11))
-    local glyph_gap = math.max(glyph_size * 3, math.floor(cell * 0.34))
-    local streams = {}
-    local max_frame = 72
-
-    for col = 1, stream_count do
-        streams[col] = {
-            x = board_x + math.floor((col - 0.5) * stream_gap),
-            delay = (col * 7 + col * col) % 12,
-            speed = math.max(6, math.floor(cell * (0.44 + ((col * 5) % 7) * 0.045))),
-            length = 10 + ((col * 11) % 14),
-            phase = (col * 13) % 5,
-        }
-    end
-
-    for frame = 0, max_frame do
-        display.begin_frame({ clear = true, color = BG })
-        draw_background()
-        draw_hud()
-        draw_board_shell()
-
-        for col = 1, stream_count do
-            local stream = streams[col]
-            local elapsed = frame - stream.delay
-            if elapsed >= 0 then
-                local head_y = board_y - glyph_gap + elapsed * stream.speed
-                for glyph = 0, stream.length - 1 do
-                    local y = head_y - glyph * glyph_gap
-                    if y >= board_y + glyph_size and y <= board_y + board_size - glyph_size then
-                        local pulse = (frame + glyph + stream.phase) % 6
-                        local color = pulse == 0 and TEXT or (pulse <= 2 and CYAN or CYAN_DIM)
-                        draw_data_glyph(stream.x, y, glyph_size,
-                            (glyph + stream.phase) % 3, color)
-                    end
-                end
-            end
-        end
-
-        display.present()
-        display.end_frame()
-        delay.delay_ms(28)
-    end
-
-    for line = 0, GRID_N do
-        display.begin_frame({ clear = true, color = BG })
-        draw_background()
-        draw_hud()
-        draw_board_shell()
-        for i = 0, line do
-            local p = i * cell
-            display.draw_line(board_x + p, board_y, board_x + p, board_y + board_size, GRID_LINE)
-            display.draw_line(board_x, board_y + p, board_x + board_size, board_y + p, GRID_LINE)
-        end
-        display.present()
-        display.end_frame()
-        delay.delay_ms(20)
-    end
-
-    phase = "playing"
-    last_step_ms = now_ms()
-    render(true, true)
-end
-
 local function direction_from_swipe(dx, dy)
     if math.abs(dx) < swipe_threshold and math.abs(dy) < swipe_threshold then return nil end
     if math.abs(dx) > math.abs(dy) then return dx > 0 and "right" or "left" end
@@ -776,7 +667,6 @@ local function handle_touch()
     return false
 end
 
-draw_boot_animation()
 reset_game(nil)
 render(true, true)
 print(string.format("[snake_game] ready screen=%dx%d board=%dx%d grid=%d swipe=%d run_ms=%d",
@@ -800,7 +690,8 @@ local run_ok, run_err = xpcall(function()
                     render(true, true)
                 end
             elseif phase == "ready" then
-                draw_deploy_animation(action)
+                reset_game(action)
+                render(true, true)
             elseif phase == "game_over" then
                 reset_game(action)
                 render(true, true)

--- a/skills/snake_game/scripts/snake_game.lua
+++ b/skills/snake_game/scripts/snake_game.lua
@@ -1,0 +1,824 @@
+local bm = require("board_manager")
+local display = require("display")
+local delay = require("delay")
+local system_ok, system = pcall(require, "system")
+local touch_ok, lcd_touch = pcall(require, "lcd_touch")
+local audio_ok, audio = pcall(require, "audio")
+
+local a = type(args) == "table" and args or {}
+
+local function int_arg(name, default)
+    local value = a[name]
+    if type(value) == "number" then
+        return math.floor(value)
+    end
+    return default
+end
+
+local function now_ms()
+    if system_ok and system and system.millis then
+        return system.millis()
+    end
+    return math.floor(os.clock() * 1000)
+end
+
+local function rgb(r, g, b)
+    return { r = math.floor(r), g = math.floor(g), b = math.floor(b) }
+end
+
+local function clamp(v, lo, hi)
+    if v < lo then return lo end
+    if v > hi then return hi end
+    return v
+end
+
+local function lerp(a0, b0, t)
+    return a0 + (b0 - a0) * t
+end
+
+local function mix_color(a0, b0, t)
+    return rgb(lerp(a0.r, b0.r, t), lerp(a0.g, b0.g, t), lerp(a0.b, b0.b, t))
+end
+
+local RUN_TIME_MS = int_arg("run_time_ms", 180000)
+local TARGET_SIZE = int_arg("target_size", 0)
+if TARGET_SIZE > 0 then TARGET_SIZE = clamp(TARGET_SIZE, 160, 1600) end
+local GRID_N = clamp(int_arg("grid_size", 15), 12, 30)
+local FRAME_MS = 16
+local START_STEP_MS = 300
+local MIN_STEP_MS = 140
+local SOUND_VOLUME = 84
+local UAC_FLUSH_PCM_BYTES = 4000
+
+local output_codec, board_output_rate, output_channels, output_bits =
+    bm.get_audio_codec_output_params("audio_dac")
+local OUTPUT_SAMPLE_RATE = int_arg("sample_rate_hz", board_output_rate or 16000)
+
+local panel, io, width, height, panel_if = bm.get_display_lcd_params("display_lcd")
+if not panel then
+    print("[snake_game] ERROR: get_display_lcd_params(display_lcd) failed: " .. tostring(io))
+    return
+end
+
+local ok, err = pcall(display.init, panel, io, width, height, panel_if)
+if not ok then
+    print("[snake_game] ERROR: display.init failed: " .. tostring(err))
+    return
+end
+
+local screen_ready = true
+width = display.width
+height = display.height
+
+local touch_handle = nil
+local audio_output = nil
+local sfx = {}
+local pending_sfx = nil
+
+local function cleanup()
+    if audio_output then
+        pcall(audio_output.close, audio_output)
+        audio_output = nil
+    end
+    if screen_ready then
+        pcall(display.end_frame)
+        pcall(display.deinit)
+        screen_ready = false
+    end
+end
+
+if width <= 0 or height <= 0 then
+    print("[snake_game] ERROR: invalid display size")
+    cleanup()
+    return
+end
+
+if not touch_ok then
+    print("[snake_game] ERROR: require(lcd_touch) failed")
+    cleanup()
+    return
+end
+
+local touch_err
+touch_handle, touch_err = bm.get_lcd_touch_handle("lcd_touch")
+if not touch_handle then
+    print("[snake_game] ERROR: get_lcd_touch_handle(lcd_touch) failed: " .. tostring(touch_err))
+    cleanup()
+    return
+end
+
+local synced, sync_err = pcall(lcd_touch.sync, touch_handle)
+if not synced then
+    print("[snake_game] ERROR: lcd_touch.sync failed: " .. tostring(sync_err))
+    cleanup()
+    return
+end
+
+local function build_tone(freq_hz, duration_ms, amp)
+    local rate = OUTPUT_SAMPLE_RATE
+    local frames = math.floor(rate * duration_ms / 1000)
+    if frames <= 0 then
+        return string.rep("\0", UAC_FLUSH_PCM_BYTES)
+    end
+
+    local chunks = {}
+    local phase_value = 0
+    local phase_step = 2 * math.pi * freq_hz / rate
+    for i = 1, frames do
+        local raw = math.sin(phase_value) >= 0 and 1 or -1
+        local fade = 1
+        if i > frames * 0.7 then
+            fade = (frames - i) / math.max(1, frames * 0.3)
+        end
+        local sample = math.floor(raw * amp * fade)
+        phase_value = phase_value + phase_step
+        sample = clamp(sample, -32768, 32767)
+        local u = sample < 0 and sample + 65536 or sample
+        chunks[i] = string.char(u % 256, math.floor(u / 256) % 256)
+    end
+
+    local pcm = table.concat(chunks)
+    if #pcm < UAC_FLUSH_PCM_BYTES then
+        pcm = pcm .. string.rep("\0", UAC_FLUSH_PCM_BYTES - #pcm)
+    end
+    return pcm
+end
+
+local function init_audio()
+    if not audio_ok or not output_codec then
+        print("[snake_game] WARN: audio unavailable")
+        return
+    end
+
+    local out_ok, out = pcall(function()
+        return audio.new_output({
+            codec = output_codec,
+            sample_rate = OUTPUT_SAMPLE_RATE,
+            channels = output_channels,
+            bits = output_bits,
+            volume = SOUND_VOLUME,
+        })
+    end)
+    if not out_ok or not out then
+        print("[snake_game] WARN: audio init failed: " .. tostring(out))
+        return
+    end
+
+    audio_output = out
+    sfx.start = build_tone(660, 90, 11000)
+    sfx.turn = build_tone(420, 45, 7500)
+    sfx.food = build_tone(980, 85, 13000)
+    sfx.crash = build_tone(150, 240, 12000)
+end
+
+local function request_sfx(name)
+    if sfx[name] then pending_sfx = sfx[name] end
+end
+
+local function drain_sfx()
+    if not pending_sfx or not audio_output then return end
+    local wrote, write_err = audio_output:write(pending_sfx)
+    if wrote or (write_err and not tostring(write_err):find("busy", 1, true)) then
+        pending_sfx = nil
+    end
+end
+
+init_audio()
+
+local BG = rgb(2, 8, 20)
+local BG_STAR = rgb(22, 62, 104)
+local PANEL = rgb(5, 18, 38)
+local PANEL_ALT = rgb(7, 25, 50)
+local BOARD_BG = rgb(3, 14, 31)
+local GRID_LINE = rgb(12, 43, 72)
+local BORDER = rgb(32, 111, 172)
+local BORDER_HI = rgb(102, 224, 255)
+local TEXT = rgb(238, 251, 255)
+local SUBTEXT = rgb(116, 178, 211)
+local CYAN = rgb(75, 218, 255)
+local CYAN_DIM = rgb(19, 92, 137)
+local WHITE_BLUE = rgb(190, 239, 255)
+local SHADOW = rgb(1, 4, 12)
+
+local BODY_PALETTE = {
+    rgb(89, 224, 255),
+    rgb(92, 157, 255),
+    rgb(139, 112, 255),
+    rgb(226, 96, 241),
+    rgb(255, 102, 158),
+    rgb(255, 183, 84),
+    rgb(128, 241, 191),
+}
+
+local short_side = math.min(width, height)
+local pad = math.max(6, math.floor(short_side * 0.025))
+local gap = math.max(8, math.floor(short_side * 0.025))
+local landscape = width >= 560 and width / height >= 1.25
+local board_x, board_y, board_size, cell
+local hud_x, hud_y, hud_w, hud_h
+
+if landscape then
+    hud_w = clamp(math.floor(width * 0.27), 180, math.floor(width * 0.34))
+    hud_x = width - pad - hud_w
+    hud_y = pad
+    hud_h = height - pad * 2
+    local available_w = hud_x - gap - pad
+    local available_h = height - pad * 2
+    cell = math.max(4, math.floor(math.min(available_w, available_h) / GRID_N))
+    if TARGET_SIZE > 0 then cell = math.min(cell, math.floor(TARGET_SIZE / GRID_N)) end
+    board_size = cell * GRID_N
+    board_x = pad + math.floor((available_w - board_size) / 2)
+    board_y = pad + math.floor((available_h - board_size) / 2)
+else
+    hud_x = pad
+    hud_y = pad
+    hud_w = width - pad * 2
+    hud_h = clamp(math.floor(height * 0.18), 58, 112)
+    local available_w = width - pad * 2
+    local available_h = height - hud_h - gap - pad * 2
+    cell = math.max(4, math.floor(math.min(available_w, available_h) / GRID_N))
+    if TARGET_SIZE > 0 then cell = math.min(cell, math.floor(TARGET_SIZE / GRID_N)) end
+    board_size = cell * GRID_N
+    board_x = pad + math.floor((available_w - board_size) / 2)
+    board_y = hud_y + hud_h + gap + math.floor((available_h - board_size) / 2)
+end
+
+local swipe_threshold = clamp(math.floor(short_side * 0.05), 20, 36)
+local title_font = clamp(math.floor(short_side * 0.075), 22, 40)
+local stat_font = clamp(math.floor(short_side * 0.042), 14, 24)
+local small_font = clamp(math.floor(short_side * 0.027), 10, 15)
+local pause_h = landscape and clamp(math.floor(hud_h * 0.09), 34, 44) or math.max(30, hud_h - 16)
+local pause_w = landscape and hud_w or clamp(math.floor(hud_w * 0.18), 72, 112)
+local pause_x = landscape and hud_x or hud_x + hud_w - pause_w - 8
+local pause_y = hud_y + 8
+if landscape then
+    local cards_y = hud_y + title_font + small_font + 18
+    local card_gap = math.max(5, math.floor(hud_h * 0.014))
+    local card_h = clamp(math.floor(hud_h * 0.115), 38, 58)
+    local status_y = cards_y + (card_h + card_gap) * 3 + math.max(8, gap)
+    pause_y = math.min(status_y + small_font * 2 + 12, hud_y + hud_h - pause_h)
+end
+
+local snake = {}
+local food = { x = 1, y = 1 }
+local dir = "right"
+local pending_dir = "right"
+local score = 0
+local best = 0
+local phase = "ready"
+local won = false
+local touch_down = nil
+local last_step_ms = 0
+local step_ms = START_STEP_MS
+
+math.randomseed((os.time() or 1) + width * 13 + height * 29 + now_ms())
+
+local DIRS = {
+    up = { dx = 0, dy = -1 },
+    down = { dx = 0, dy = 1 },
+    left = { dx = -1, dy = 0 },
+    right = { dx = 1, dy = 0 },
+}
+
+local OPPOSITE = {
+    up = "down",
+    down = "up",
+    left = "right",
+    right = "left",
+}
+
+local function cell_center(x, y)
+    return board_x + math.floor((x - 0.5) * cell), board_y + math.floor((y - 0.5) * cell)
+end
+
+local function occupies(x, y, max_index)
+    local last = max_index or #snake
+    for i = 1, last do
+        if snake[i].x == x and snake[i].y == y then return true end
+    end
+    return false
+end
+
+local function place_food()
+    local free = {}
+    for y = 1, GRID_N do
+        for x = 1, GRID_N do
+            if not occupies(x, y) then free[#free + 1] = { x = x, y = y } end
+        end
+    end
+    if #free == 0 then
+        won = true
+        phase = "game_over"
+        return
+    end
+    food = free[math.random(1, #free)]
+end
+
+local function update_speed()
+    step_ms = math.max(MIN_STEP_MS, START_STEP_MS - math.floor(score / 5) * 10)
+end
+
+local function reset_game(start_dir)
+    local next_dir = start_dir or "right"
+    local delta = DIRS[next_dir]
+    local cx = math.floor(GRID_N / 2) + 1
+    local cy = math.floor(GRID_N / 2) + 1
+    snake = {
+        { x = cx, y = cy },
+        { x = cx - delta.dx, y = cy - delta.dy },
+        { x = cx - delta.dx * 2, y = cy - delta.dy * 2 },
+    }
+    dir = next_dir
+    pending_dir = next_dir
+    score = 0
+    won = false
+    phase = start_dir and "playing" or "ready"
+    touch_down = nil
+    update_speed()
+    place_food()
+    last_step_ms = now_ms()
+    if start_dir then request_sfx("start") end
+end
+
+local function set_direction(next_dir)
+    if not DIRS[next_dir] or next_dir == OPPOSITE[dir] then return false end
+    if next_dir ~= pending_dir then
+        pending_dir = next_dir
+        request_sfx("turn")
+    end
+    return true
+end
+
+local function step_game()
+    if phase ~= "playing" then return { idle = true } end
+    dir = pending_dir
+    local delta = DIRS[dir]
+    local head = snake[1]
+    local nx = head.x + delta.dx
+    local ny = head.y + delta.dy
+    local eating = nx == food.x and ny == food.y
+
+    if nx < 1 or nx > GRID_N or ny < 1 or ny > GRID_N then
+        phase = "game_over"
+        request_sfx("crash")
+        return { game_over = true }
+    end
+
+    local check_until = eating and #snake or (#snake - 1)
+    if occupies(nx, ny, check_until) then
+        phase = "game_over"
+        request_sfx("crash")
+        return { game_over = true }
+    end
+
+    table.insert(snake, 1, { x = nx, y = ny })
+    if eating then
+        score = score + 1
+        if score > best then best = score end
+        update_speed()
+        request_sfx("food")
+        place_food()
+    else
+        table.remove(snake)
+    end
+    return { moved = true, eating = eating }
+end
+
+local function draw_background()
+    display.clear(BG)
+    for i = 1, 30 do
+        local x = (i * 83 + 17) % width
+        local y = (i * 47 + 29) % height
+        display.fill_rect(x, y, i % 5 == 0 and 2 or 1, i % 5 == 0 and 2 or 1, BG_STAR)
+    end
+end
+
+local function draw_stat_card(x, y, w, h, label, value, accent)
+    local radius = math.max(4, math.floor(h * 0.12))
+    display.fill_round_rect(x, y, w, h, radius, PANEL_ALT)
+    display.draw_round_rect(x, y, w, h, radius, accent)
+    local label_w = math.floor(w * 0.52)
+    display.draw_text_aligned(x + 10, y, label_w - 10, h, label, {
+        color = SUBTEXT, font_size = small_font, align = "left", valign = "middle", bg = PANEL_ALT,
+    })
+    display.draw_text_aligned(x + label_w, y, w - label_w - 10, h, tostring(value), {
+        color = accent, font_size = stat_font, align = "right", valign = "middle", bg = PANEL_ALT,
+    })
+end
+
+local function draw_pause_button()
+    local active = phase == "playing" or phase == "paused"
+    local color = active and CYAN or CYAN_DIM
+    local label = phase == "paused" and "RESUME" or "PAUSE"
+    display.fill_round_rect(pause_x, pause_y, pause_w, pause_h, 6, PANEL_ALT)
+    display.draw_round_rect(pause_x, pause_y, pause_w, pause_h, 6, color)
+    display.draw_text_aligned(pause_x, pause_y, pause_w, pause_h, label, {
+        color = color, font_size = small_font, align = "center", valign = "middle", bg = PANEL_ALT,
+    })
+end
+
+local function draw_hud()
+    if landscape then
+        display.fill_rect(hud_x, hud_y, hud_w, hud_h, BG)
+        display.draw_text_aligned(hud_x, hud_y, hud_w, title_font + 8, "SNAKE", {
+            color = TEXT, font_size = title_font, align = "center", valign = "middle", bg = BG,
+        })
+        display.draw_text_aligned(hud_x, hud_y + title_font + 2, hud_w, small_font + 8, "DATA STREAM", {
+            color = CYAN, font_size = small_font, align = "center", valign = "middle", bg = BG,
+        })
+
+        local cards_y = hud_y + title_font + small_font + 18
+        local card_gap = math.max(5, math.floor(hud_h * 0.014))
+        local card_h = clamp(math.floor(hud_h * 0.115), 38, 58)
+        draw_stat_card(hud_x, cards_y, hud_w, card_h, "SCORE", score, CYAN)
+        draw_stat_card(hud_x, cards_y + card_h + card_gap, hud_w, card_h, "BEST", best, WHITE_BLUE)
+        draw_stat_card(hud_x, cards_y + (card_h + card_gap) * 2, hud_w, card_h,
+            "LEVEL", 1 + math.floor(score / 5), CYAN)
+        local status_y = cards_y + (card_h + card_gap) * 3 + math.max(8, gap)
+        display.draw_line(hud_x + 8, status_y, hud_x + hud_w - 8, status_y, CYAN_DIM)
+        display.draw_text_aligned(hud_x, status_y + 5, hud_w, small_font * 2, "SWIPE TO STEER", {
+            color = SUBTEXT, font_size = small_font, align = "center", valign = "middle", bg = BG,
+        })
+        draw_pause_button()
+    else
+        display.fill_round_rect(hud_x, hud_y, hud_w, hud_h, 7, PANEL)
+        display.draw_round_rect(hud_x, hud_y, hud_w, hud_h, 7, BORDER)
+        local title_w = math.floor(hud_w * 0.30)
+        display.draw_text_aligned(hud_x + 6, hud_y, title_w, hud_h, "SNAKE", {
+            color = CYAN, font_size = title_font, align = "left", valign = "middle", bg = PANEL,
+        })
+        local stats_x = hud_x + title_w
+        local stats_w = pause_x - stats_x - 6
+        local line = string.format("SCORE %d   BEST %d   LV %d", score, best, 1 + math.floor(score / 5))
+        display.draw_text_aligned(stats_x, hud_y, stats_w, hud_h, line, {
+            color = TEXT, font_size = small_font, align = "center", valign = "middle", bg = PANEL,
+        })
+        draw_pause_button()
+    end
+end
+
+local function draw_board_shell()
+    local radius = math.max(5, math.floor(cell * 0.35))
+    display.fill_round_rect(board_x + 4, board_y + 5, board_size, board_size, radius, SHADOW)
+    display.fill_round_rect(board_x, board_y, board_size, board_size, radius, BOARD_BG)
+    display.draw_round_rect(board_x, board_y, board_size, board_size, radius, BORDER_HI)
+    display.draw_round_rect(board_x + 2, board_y + 2, board_size - 4, board_size - 4, radius, BORDER)
+end
+
+local function draw_board_base()
+    draw_board_shell()
+    for i = 0, GRID_N do
+        local p = i * cell
+        display.draw_line(board_x + p, board_y, board_x + p, board_y + board_size, GRID_LINE)
+        display.draw_line(board_x, board_y + p, board_x + board_size, board_y + p, GRID_LINE)
+    end
+end
+
+local function body_color(index)
+    local unlocked = clamp(1 + (#snake - 3), 1, #BODY_PALETTE)
+    if #snake <= 1 or unlocked == 1 then return BODY_PALETTE[1] end
+    local scaled = (index - 1) / (#snake - 1) * (unlocked - 1)
+    local left = math.floor(scaled) + 1
+    local right = math.min(unlocked, left + 1)
+    return mix_color(BODY_PALETTE[left], BODY_PALETTE[right], scaled - math.floor(scaled))
+end
+
+local function body_radius(index)
+    local base = math.max(3, math.floor(cell * 0.36))
+    local from_tail = #snake - index
+    if from_tail >= 2 then return base end
+    return math.max(2, math.floor(base * (0.6 + from_tail * 0.2)))
+end
+
+local function draw_link(a0, b0, radius, color, ox, oy)
+    local ax, ay = cell_center(a0.x, a0.y)
+    local bx, by = cell_center(b0.x, b0.y)
+    ax, ay, bx, by = ax + ox, ay + oy, bx + ox, by + oy
+    if ax == bx then
+        display.fill_rect(ax - radius, math.min(ay, by), radius * 2 + 1, math.abs(by - ay) + 1, color)
+    else
+        display.fill_rect(math.min(ax, bx), ay - radius, math.abs(bx - ax) + 1, radius * 2 + 1, color)
+    end
+end
+
+local function draw_snake_body()
+    for i = 1, #snake - 1 do
+        local radius = math.min(body_radius(i), body_radius(i + 1)) + 2
+        draw_link(snake[i], snake[i + 1], radius, SHADOW, 2, 3)
+    end
+    for i = #snake, 2, -1 do
+        local x, y = cell_center(snake[i].x, snake[i].y)
+        display.fill_circle(x + 2, y + 3, body_radius(i) + 2, SHADOW)
+    end
+
+    for i = 1, #snake - 1 do
+        local radius = math.min(body_radius(i), body_radius(i + 1))
+        draw_link(snake[i], snake[i + 1], radius, body_color(i + 0.5), 0, 0)
+    end
+    for i = #snake, 2, -1 do
+        local x, y = cell_center(snake[i].x, snake[i].y)
+        display.fill_circle(x, y, body_radius(i), body_color(i))
+    end
+end
+
+local function local_point(cx, cy, forward, side, f, s)
+    return math.floor(cx + forward.dx * f + side.dx * s),
+        math.floor(cy + forward.dy * f + side.dy * s)
+end
+
+local function draw_snake_head()
+    local head = snake[1]
+    local cx, cy = cell_center(head.x, head.y)
+    local forward = DIRS[dir]
+    local side = { dx = -forward.dy, dy = forward.dx }
+    local rx = math.max(6, math.floor(cell * (forward.dx ~= 0 and 0.54 or 0.41)))
+    local ry = math.max(6, math.floor(cell * (forward.dy ~= 0 and 0.54 or 0.41)))
+    local shift = math.floor(cell * 0.12)
+    cx = cx + forward.dx * shift
+    cy = cy + forward.dy * shift
+
+    display.fill_ellipse(cx + 2, cy + 3, rx + 2, ry + 2, SHADOW)
+    display.fill_ellipse(cx, cy, rx + 1, ry + 1, CYAN_DIM)
+    display.fill_ellipse(cx, cy, rx, ry, WHITE_BLUE)
+
+    local nose_f = math.floor(cell * 0.34)
+    local nose_half = math.max(2, math.floor(cell * 0.12))
+    local nx, ny = local_point(cx, cy, forward, side, nose_f, 0)
+    local bx1, by1 = local_point(cx, cy, forward, side, math.floor(cell * 0.02), -nose_half)
+    local bx2, by2 = local_point(cx, cy, forward, side, math.floor(cell * 0.02), nose_half)
+    display.fill_triangle(nx, ny, bx1, by1, bx2, by2, CYAN)
+
+    local core_f = math.floor(cell * 0.05)
+    local core_r = math.max(2, math.floor(cell * 0.12))
+    local core_x, core_y = local_point(cx, cy, forward, side, core_f, 0)
+    display.fill_circle(core_x, core_y, core_r + 2, rgb(11, 54, 89))
+    display.fill_circle(core_x, core_y, core_r, CYAN)
+    display.fill_circle(core_x - side.dx, core_y - side.dy, math.max(1, core_r // 3), TEXT)
+
+    local fin_f = -math.floor(cell * 0.15)
+    local fin_side = math.max(3, math.floor(cell * 0.25))
+    local tail_x, tail_y = local_point(cx, cy, forward, side, -math.floor(cell * 0.38), 0)
+    local f1x, f1y = local_point(cx, cy, forward, side, fin_f, -fin_side)
+    local f2x, f2y = local_point(cx, cy, forward, side, fin_f, fin_side)
+    display.draw_line(tail_x, tail_y, f1x, f1y, CYAN)
+    display.draw_line(tail_x, tail_y, f2x, f2y, CYAN)
+end
+
+local function draw_data_cursor(cx, cy, r, color)
+    local arm = r + math.max(2, math.floor(r * 0.55))
+    display.draw_line(cx - arm, cy, cx - r, cy, CYAN_DIM)
+    display.draw_line(cx + r, cy, cx + arm, cy, CYAN_DIM)
+    display.draw_line(cx, cy - arm, cx, cy - r, CYAN_DIM)
+    display.draw_line(cx, cy + r, cx, cy + arm, CYAN_DIM)
+    display.draw_round_rect(cx - r, cy - r, r * 2, r * 2, 2, color)
+end
+
+local function draw_data_glyph(x, y, size, variant, color)
+    if variant == 0 then
+        display.draw_line(x, y - size, x, y + size, color)
+        display.draw_line(x, y - size, x + size, y - size, color)
+        display.draw_line(x, y, x - size, y + size, color)
+    elseif variant == 1 then
+        display.draw_round_rect(x - size, y - size, size * 2, size * 2, 1, color)
+        display.draw_line(x - size, y, x + size, y, color)
+    else
+        display.draw_line(x - size, y - size, x + size, y - size, color)
+        display.draw_line(x + size, y - size, x - size, y + size, color)
+        display.draw_line(x - size, y + size, x + size, y + size, color)
+    end
+end
+
+local function draw_food()
+    local cx, cy = cell_center(food.x, food.y)
+    local r = math.max(4, math.floor(cell * 0.28))
+    draw_data_cursor(cx, cy, r, CYAN)
+    display.fill_rect(cx - math.max(1, r // 3), cy - math.max(1, r // 3),
+        math.max(3, r * 2 // 3), math.max(3, r * 2 // 3), TEXT)
+end
+
+local function draw_overlay()
+    if phase == "playing" then return end
+    local panel_w = math.min(math.floor(board_size * 0.74), 390)
+    local panel_h = clamp(math.floor(board_size * 0.20), 68, 96)
+    local x = board_x + math.floor((board_size - panel_w) / 2)
+    local y = phase == "ready"
+        and board_y + board_size - panel_h - math.max(8, math.floor(cell * 0.5))
+        or board_y + math.floor((board_size - panel_h) / 2)
+    local accent = CYAN
+    local title = phase == "ready" and "READY?"
+        or (phase == "paused" and "PAUSED" or (won and "YOU WIN!" or "GAME OVER"))
+    local hint = phase == "ready" and "SWIPE TO START"
+        or (phase == "paused" and "TAP RESUME" or "SWIPE TO RESTART")
+    display.fill_round_rect(x + 4, y + 5, panel_w, panel_h, 9, SHADOW)
+    display.fill_round_rect(x, y, panel_w, panel_h, 9, PANEL)
+    display.draw_round_rect(x, y, panel_w, panel_h, 9, accent)
+    display.draw_text_aligned(x, y + 4, panel_w, math.floor(panel_h * 0.52), title, {
+        color = TEXT, font_size = clamp(math.floor(panel_h * 0.28), 18, 28),
+        align = "center", valign = "middle", bg = PANEL,
+    })
+    display.draw_text_aligned(x, y + math.floor(panel_h * 0.52), panel_w, math.floor(panel_h * 0.38), hint, {
+        color = CYAN, font_size = small_font, align = "center", valign = "middle", bg = PANEL,
+    })
+end
+
+local function draw_board_content()
+    if phase == "ready" then
+        draw_board_shell()
+        draw_overlay()
+        return
+    end
+    draw_board_base()
+    draw_food()
+    draw_snake_body()
+    draw_snake_head()
+    draw_overlay()
+end
+
+local function render(full, refresh_hud)
+    display.begin_frame({ clear = full, color = BG })
+    if full then draw_background() end
+    if full or refresh_hud then draw_hud() end
+    draw_board_content()
+    display.present()
+    display.end_frame()
+end
+
+local function draw_boot_animation()
+    local panel_w = math.min(math.floor(board_size * 0.68), 360)
+    local panel_h = clamp(math.floor(board_size * 0.24), 82, 116)
+    local x = board_x + math.floor((board_size - panel_w) / 2)
+    local y = board_y + math.floor((board_size - panel_h) / 2)
+    local bar_x = x + math.floor(panel_w * 0.12)
+    local bar_y = y + math.floor(panel_h * 0.64)
+    local bar_w = math.floor(panel_w * 0.76)
+    local bar_h = math.max(5, math.floor(panel_h * 0.07))
+
+    for frame = 0, 12 do
+        display.begin_frame({ clear = true, color = BG })
+        draw_background()
+        draw_hud()
+        draw_board_shell()
+        display.fill_round_rect(x, y, panel_w, panel_h, 7, PANEL)
+        display.draw_round_rect(x, y, panel_w, panel_h, 7, BORDER_HI)
+        display.draw_text_aligned(x, y + 8, panel_w, math.floor(panel_h * 0.32), "SYSTEM LINK", {
+            color = TEXT, font_size = stat_font, align = "center", valign = "middle", bg = PANEL,
+        })
+        local dots = string.rep(".", frame % 4)
+        display.draw_text_aligned(x, y + math.floor(panel_h * 0.35), panel_w, math.floor(panel_h * 0.22),
+            "LOADING DATA" .. dots, {
+                color = CYAN, font_size = small_font, align = "center", valign = "middle", bg = PANEL,
+            })
+        display.fill_rect(bar_x, bar_y, bar_w, bar_h, CYAN_DIM)
+        if frame > 0 then
+            display.fill_rect(bar_x, bar_y, math.floor(bar_w * frame / 12), bar_h, CYAN)
+        end
+        display.present()
+        display.end_frame()
+        delay.delay_ms(55)
+    end
+end
+
+local function draw_deploy_animation(start_dir)
+    reset_game(start_dir)
+    phase = "deploying"
+    local stream_count = math.max(GRID_N + 6, math.floor(board_size / math.max(10, cell * 0.58)))
+    local stream_gap = board_size / stream_count
+    local glyph_size = math.max(2, math.floor(cell * 0.11))
+    local glyph_gap = math.max(glyph_size * 3, math.floor(cell * 0.34))
+    local streams = {}
+    local max_frame = 72
+
+    for col = 1, stream_count do
+        streams[col] = {
+            x = board_x + math.floor((col - 0.5) * stream_gap),
+            delay = (col * 7 + col * col) % 12,
+            speed = math.max(6, math.floor(cell * (0.44 + ((col * 5) % 7) * 0.045))),
+            length = 10 + ((col * 11) % 14),
+            phase = (col * 13) % 5,
+        }
+    end
+
+    for frame = 0, max_frame do
+        display.begin_frame({ clear = true, color = BG })
+        draw_background()
+        draw_hud()
+        draw_board_shell()
+
+        for col = 1, stream_count do
+            local stream = streams[col]
+            local elapsed = frame - stream.delay
+            if elapsed >= 0 then
+                local head_y = board_y - glyph_gap + elapsed * stream.speed
+                for glyph = 0, stream.length - 1 do
+                    local y = head_y - glyph * glyph_gap
+                    if y >= board_y + glyph_size and y <= board_y + board_size - glyph_size then
+                        local pulse = (frame + glyph + stream.phase) % 6
+                        local color = pulse == 0 and TEXT or (pulse <= 2 and CYAN or CYAN_DIM)
+                        draw_data_glyph(stream.x, y, glyph_size,
+                            (glyph + stream.phase) % 3, color)
+                    end
+                end
+            end
+        end
+
+        display.present()
+        display.end_frame()
+        delay.delay_ms(28)
+    end
+
+    for line = 0, GRID_N do
+        display.begin_frame({ clear = true, color = BG })
+        draw_background()
+        draw_hud()
+        draw_board_shell()
+        for i = 0, line do
+            local p = i * cell
+            display.draw_line(board_x + p, board_y, board_x + p, board_y + board_size, GRID_LINE)
+            display.draw_line(board_x, board_y + p, board_x + board_size, board_y + p, GRID_LINE)
+        end
+        display.present()
+        display.end_frame()
+        delay.delay_ms(20)
+    end
+
+    phase = "playing"
+    last_step_ms = now_ms()
+    render(true, true)
+end
+
+local function direction_from_swipe(dx, dy)
+    if math.abs(dx) < swipe_threshold and math.abs(dy) < swipe_threshold then return nil end
+    if math.abs(dx) > math.abs(dy) then return dx > 0 and "right" or "left" end
+    return dy > 0 and "down" or "up"
+end
+
+local function handle_touch()
+    local polled, info = pcall(lcd_touch.poll, touch_handle)
+    if not polled then
+        print("[snake_game] ERROR: lcd_touch.poll failed: " .. tostring(info))
+        return nil
+    end
+    if info.pressed then
+        if not touch_down then touch_down = { x = info.x, y = info.y } end
+    elseif info.just_released then
+        if not touch_down then return false end
+        local dx = info.x - touch_down.x
+        local dy = info.y - touch_down.y
+        touch_down = nil
+        if math.abs(dx) < swipe_threshold and math.abs(dy) < swipe_threshold
+            and info.x >= pause_x and info.x <= pause_x + pause_w
+            and info.y >= pause_y and info.y <= pause_y + pause_h then
+            return "toggle_pause"
+        end
+        local action = direction_from_swipe(dx, dy)
+        return action or false
+    end
+    return false
+end
+
+draw_boot_animation()
+reset_game(nil)
+render(true, true)
+print(string.format("[snake_game] ready screen=%dx%d board=%dx%d grid=%d swipe=%d run_ms=%d",
+    width, height, board_size, board_size, GRID_N, swipe_threshold, RUN_TIME_MS))
+print("[snake_game] swipe up/down/left/right to start and steer")
+
+local run_ok, run_err = xpcall(function()
+    local run_start = now_ms()
+    while now_ms() - run_start < RUN_TIME_MS do
+        drain_sfx()
+        local action = handle_touch()
+        if action == nil then break end
+        if action then
+            if action == "toggle_pause" then
+                if phase == "playing" then
+                    phase = "paused"
+                    render(true, true)
+                elseif phase == "paused" then
+                    phase = "playing"
+                    last_step_ms = now_ms()
+                    render(true, true)
+                end
+            elseif phase == "ready" then
+                draw_deploy_animation(action)
+            elseif phase == "game_over" then
+                reset_game(action)
+                render(true, true)
+            elseif phase == "playing" then
+                set_direction(action)
+            end
+        end
+
+        local now = now_ms()
+        if phase == "playing" and now - last_step_ms >= step_ms then
+            last_step_ms = now
+            local change = step_game()
+            render(false, change.eating)
+        end
+        delay.delay_ms(FRAME_MS)
+    end
+end, debug.traceback)
+
+cleanup()
+if not run_ok then print("[snake_game] ERROR: " .. tostring(run_err)) end
+print("[snake_game] done")


### PR DESCRIPTION
## Description

This PR adds three touch-controlled LCD game skills:

- **Snake Game**
  - Classic swipe-controlled Snake gameplay.
  - Includes pause/resume controls, increasing speed, restart support, boot animations, evolving trail colors, and optional sound effects.

- **2048**
  - Implements the complete 2048 movement, merging, scoring, and game-over logic.
  - Includes swipe controls, tile animations, responsive rendering, and optional sound effects.

- **Number Puzzle**
  - Implements a touch-controlled 4×4 sliding number puzzle.
  - Supports both tapping adjacent tiles and swipe gestures.
  - Generates solvable boards using legal shuffle moves and displays move count and elapsed time.

All three skills include simulator entry metadata, responsive LCD layouts, configurable runtime/display options, and documentation covering requirements, arguments, and controls.

The purpose of this PR is to expand the collection of interactive games available for ESP-Claw devices and the web simulator.


## Related

N/A

## Testing

Local validation:

- [x] `pnpm exec oxfmt --check`
- [x] `pnpm validate-skills`
- [x] `pnpm build`

Manual testing:

- [x] Snake movement, collision, food, pause/resume, game over, and restart
- [x] 2048 movement, tile merging, scoring, and game over
- [x] Number Puzzle tap/swipe controls, solvable shuffle, and completion detection
- [x] Rendering on the web simulator or a physical LCD device
- [x] Behavior when audio output is unavailable

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.