### PR TITLE
feat(game_of_life): enable Skills Lab online try

### DIFF
--- a/skills/game_of_life/SKILL.md
+++ b/skills/game_of_life/SKILL.md
@@ -4,7 +4,7 @@
   "description": "Play an immersive full-screen Rainbow Conway's Game of Life on an ESP-Claw display. Tap to seed patterns, drag to paint or erase cells, long-press to reset, and shake an IMU-equipped board to scatter life. Uses Conway B3/S23 with no on-screen controls; LCD touch is preferred and IMU support is optional.",
   "author": "superjames",
   "metadata": {
-    "category": ["game"],
+    "category": ["game", "ui"],
     "tags": ["life", "conway", "rainbow", "arcade", "demo", "button", "touch", "shake", "accelerometer", "immersive"],
     "peripherals": ["display"],
     "cap_groups": ["cap_lua"],
@@ -16,6 +16,12 @@
     "args": {},
     "order": 20,
     "visible": true
+  },
+  "simulator": {
+    "entry": "scripts/mosaico_life.lua",
+    "files": [
+      "scripts/mosaico_life.lua"
+    ]
   }
 }
 ---


### PR DESCRIPTION
﻿## Description

Enable the Skills Lab Try Online button for Game of Life.

The Lua skill is already on master (merged in #32) and already runs in the web simulator. The lab only shows the button when metadata.category includes ui, and validate-skills then requires a simulator block. This PR adds both, matching dino / game_2048 / flappybird.

No Lua or gameplay changes.

## Related

Follow-up to #32.

## Testing

- Category is game+ui and simulator points at scripts/mosaico_life.lua
- Diff is only skills/game_of_life/SKILL.md
- Manual: Game of Life plays in the web simulator

## Checklist

- No breaking changes
- CI pending
