### PR TITLE
feat(game_of_life): Mosaico QSPI adapt (shake deferred without Lua IMU)

### DIFF
--- a/skills/game_of_life/SKILL.md
+++ b/skills/game_of_life/SKILL.md
@@ -1,13 +1,31 @@
 ---
 {
   "name": "game_of_life",
-  "description": "Play an immersive full-screen Rainbow Conway's Game of Life on an ESP-Claw display. Tap to seed patterns, drag to paint or erase cells, long-press to reset, and shake an IMU-equipped board to scatter life. Uses Conway B3/S23 with no on-screen controls; LCD touch is preferred and IMU support is optional.",
+  "description": "Play an immersive full-screen Rainbow Conway's Game of Life on ESP-Claw / Mosaico displays. Adapted for QSPI AMOLED using paced full-frame present. Tap to seed, drag to paint or erase, long-press to reset. Shake-to-scatter needs the Lua imu module; on current Mosaico firmware imu is unavailable so shake is temporarily disabled. Conway B3/S23, chrome-less full-screen; LCD touch preferred.",
   "author": "superjames",
   "metadata": {
-    "category": ["game", "ui"],
-    "tags": ["life", "conway", "rainbow", "arcade", "demo", "button", "touch", "shake", "accelerometer", "immersive"],
-    "peripherals": ["display"],
-    "cap_groups": ["cap_lua"],
+    "category": [
+      "game",
+      "ui"
+    ],
+    "tags": [
+      "life",
+      "conway",
+      "rainbow",
+      "arcade",
+      "demo",
+      "button",
+      "touch",
+      "shake",
+      "accelerometer",
+      "immersive"
+    ],
+    "peripherals": [
+      "display"
+    ],
+    "cap_groups": [
+      "cap_lua"
+    ],
     "manage_mode": "web"
   },
   "execution": {
@@ -28,9 +46,9 @@
 
 # Game of Life
 
-Use this skill when the user wants to play Conway's Game of Life, Rainbow Life, a Mosaico life demo, shake-to-scatter cells, paint living tiles on the LCD, or launch an interactive mosaic / cellular automata game.
+Use this skill when the user wants to play Conway's Game of Life, Rainbow Life, a Mosaico life demo, paint living tiles on the LCD, or launch an interactive mosaic / cellular automata game.
 
-Requires a display. Chrome-less full-screen ink canvas — no HUD buttons and no generation/status text. Uses LCD touch gestures when available; otherwise falls back to a button. If the board declares an IMU as `imu_sensor` (or the caller passes `args.imu_device`), physical board shaking triggers scatter. Audio is not required. Do not restrict this skill to a specific board model or IMU chip name.
+Requires a display. Tuned for Mosaico QSPI AMOLED (command-mode GRAM): each frame uses begin_frame, draw, present, end_frame; avoid present_full and clear=false partial paths on current firmware. Chrome-less full-screen ink canvas — no HUD buttons and no generation/status text. Uses LCD touch gestures when available; otherwise falls back to a button. IMU shake is optional and soft-required via pcall(require, "imu"). On current Mosaico firmware the Lua imu module is not registered, so shake-to-scatter is temporarily unavailable even though the board has a hardware IMU. When imu is present and the board declares imu_sensor (or args.imu_device is set), shaking still scatters life. Audio is not required.
 
 Run exactly one script with `lua_run_script` unless the user explicitly asks to run another application.
 
@@ -43,6 +61,13 @@ Tool call:
 ```json
 {"path":"{CUR_SKILL_DIR}/scripts/mosaico_life.lua","args":{}}
 ```
+
+
+## Mosaico / QSPI notes
+
+- Target panel: 480x480 QSPI AMOLED (CO5300-class GRAM). A full RGB565 frame is about 450 KB, so refresh uses paced full-frame present rather than RGB-style continuous scanout.
+- Safe Lua display path on current Mosaico image: begin_frame({ clear = true }) then draw then present() then end_frame().
+- Shake/IMU: code keeps optional IMU support, but without the Lua imu module shake does nothing until firmware enables it.
 
 Optional long-running launch (preferred for interactive play so the agent stays responsive):
 
@@ -61,9 +86,9 @@ Optional args:
 - `imu_device`: board_manager device name for the IMU (default `imu_sensor`). Use this only when the board YAML uses a non-default device id — never hard-code a board product name.
 - `shake_sensitivity`: number > 0 (default `1.0`). Higher = easier to trigger physical shake.
 - `touch_ms`: touch/button poll interval in ms (default `4`, ~250 Hz). Lower = snappier strokes.
-- `display_ms`: full-scene refresh interval in ms (default auto ~36–50 from tile count). Raise on slower panels if tearing/CPU bound.
-- `step_ms`: Life generation interval while playing (default auto ~110–150 from tile count).
-- `target_cells`: soft budget for grid tiles (default `240`). Larger panels grow cell pixels instead of denser grids, so MCU `fill_rect` cost stays bounded.
+- `display_ms`: visual refresh interval in ms (default `25` on RGB framebuffer panels, `80` on SPI/QSPI panels).
+- `step_ms`: Life generation interval (default `90` on RGB framebuffer panels, `150` on SPI/QSPI panels).
+- `target_cells`: soft budget for grid tiles (default `900` on RGB framebuffer panels, `240` on SPI/QSPI panels). Larger panels grow cell pixels instead of denser grids.
 - `cell_px`: force tile pixel size (overrides `target_cells` sizing). Use only for manual tuning.
 
 ## Recommended flow
@@ -85,7 +110,8 @@ Optional args:
 - Shake moves life in 3×3 blocks (1–3 steps) and plants viable sparks so the board does not die instantly.
 - Physical shake detection is relative to resting acceleration (scale-free), so it works across IMU backends without per-chip thresholds.
 - A restrained colored background and edge feedback add atmosphere without particle halos or on-screen chrome.
-- Tile count is capped (~240) for MCU smoothness.
+- Tile density is panel-aware: about 900 cells on RGB framebuffer panels and about 240 on SPI/QSPI panels.
+- SPI/QSPI panels automatically use horizontal dirty-band presents, final-state transitions, and a lower default cadence; RGB framebuffer panels retain the richer high-frame-rate path.
 - Single-device port of the original web demo; multi-tile linking is out of scope for this Lua skill.
 
 ## References

--- a/skills/game_of_life/references/gameplay.md
+++ b/skills/game_of_life/references/gameplay.md
@@ -68,6 +68,15 @@ Rules:
 
 ## Performance (embedded)
 
+The renderer selects its defaults from the display interface reported by Board Manager:
+
+- RGB framebuffer panels: ~900 tiles, 25 ms visual cadence, 90 ms simulation cadence, staged birth/death animation.
+- SPI/QSPI panels such as ESP-Mosaico: ~240 tiles, 80 ms visual cadence, 150 ms simulation cadence, final-state transitions.
+- QSPI/Mosaico draws into one frame and calls `present()` once. Per-band `present()` and per-row background fills are disabled because they paint the panel layer by layer.
+- Unknown panel interfaces default to the serial path so a QSPI screen is never given the RGB renderer. Override with `args.serial_panel`.
+- Consecutive dead cells on the same row are coalesced into one `fill_rect`. Live tiles use a single fill (no inset / birth spark).
+- The four-edge interaction flash and multi-frame shake displacement stay disabled on serial panels.
+
 Grid size targets **~910 tiles** on 320×240 (35×26, cell ≈ 9px), with 90 ms simulation and 25 ms visual cadences:
 
 - Each Life step only `fill_rect`s cells that changed (typically 5–15% of the board).

--- a/skills/game_of_life/scripts/mosaico_life.lua
+++ b/skills/game_of_life/scripts/mosaico_life.lua
@@ -1,7 +1,8 @@
 -- Game of Life — immersive Rainbow Conway B3/S23 for ESP-Claw displays.
 -- Full-screen ink canvas (no HUD / buttons / status text).
--- Gestures: drag paint, long-press reset, shake (IMU).
--- Optional IMU via generic `imu` + board device `imu_sensor`.
+-- Gestures: drag paint, long-press reset; shake (IMU) when Lua imu module exists.
+-- Mosaico QSPI AMOLED (CO5300 480x480): full-frame begin_frame/present/end_frame only.
+-- On current Mosaico firmware, require("imu") is unavailable so shake is disabled.
 
 local bm = require("board_manager")
 local display = require("display")
@@ -29,21 +30,21 @@ local function clamp(v, lo, hi)
 end
 
 local FRAME_MS = 5          -- 200 Hz input is responsive without starving the S3 render task
-local DISPLAY_MS = 25       -- ~40 FPS visual cadence, independent from Life steps
+local DISPLAY_MS = 40       -- 25 fps present probe
 local IMU_POLL_MS = 40
-local STEP_MS = 90          -- ~11 gen/s; three visual frames make lifecycle motion legible
-local RUN_TIME_MS = 180000
-local LONG_PRESS_MS = 700   -- reset (touch or button-only)
-local DRAG_THRESH_PX = 4    -- start paint quickly; was 10 and felt like low touch rate
+local STEP_MS = 40          -- faster gens; present stays DISPLAY_MS
+local RUN_TIME_MS = 0        -- 0 = until launcher stops the skill
+local LONG_PRESS_MS = 550   -- hold still to reset
+local DRAG_THRESH_PX = 16   -- jitter below this is still a long-press, not a drag
 local SHAKE_COOLDOWN_MS = 900
 local IMU_WARMUP_SAMPLES = 12
 -- Relative spike vs resting accel magnitude; scale-free so raw LSB / mg / g all work.
-local IMU_SHAKE_RATIO = 0.55
+local IMU_SHAKE_RATIO = 0.38
 -- Balanced composition (~S3-BOX 320x240 → cell≈9 → ~910 tiles).
 local TARGET_CELLS = 900
 local MIN_CELL_PX = 9
 local MAX_CELL_PX = 24
-local SHAKE_FX_MS = 200
+local SHAKE_FX_MS = 400
 local BIRTH_PULSE_FRAMES = 3
 local DEATH_FADE_FRAMES = 2
 local TRANSITION_LIMIT = 240
@@ -67,6 +68,9 @@ if type(args_tbl.target_cells) == "number" and args_tbl.target_cells >= 80 then
 end
 if type(args_tbl.cell_px) == "number" and args_tbl.cell_px >= 4 then
   cell_px_override = math.floor(args_tbl.cell_px)
+end
+if type(args_tbl.run_time_ms) == "number" and args_tbl.run_time_ms >= 0 then
+  RUN_TIME_MS = math.floor(args_tbl.run_time_ms)
 end
 if type(args_tbl.transition_limit) == "number" and args_tbl.transition_limit >= 0 then
   TRANSITION_LIMIT = math.floor(args_tbl.transition_limit)
@@ -92,10 +96,10 @@ end
 
 local function auto_tune_timing(n)
   if not display_ms_overridden then
-    DISPLAY_MS = 25
+    DISPLAY_MS = 40
   end
   if not step_ms_overridden then
-    STEP_MS = n > 1400 and 100 or 90
+    STEP_MS = 40
   end
 end
 
@@ -405,6 +409,8 @@ local live_count = 0
 local carry_fx_buf = {}
 local keep_fx_buf = {}
 local generation = 0
+local rendered_frames = 0
+local tick_count = 0
 
 for i = 1, n_cells do
   cells[i] = 0
@@ -906,9 +912,15 @@ local function clear_cell_index(i)
 end
 
 local function draw_background()
-  display.fill_rect(0, 0, width, height, bg_colors[1])
-  for b = 1, BG_BANDS do
-    display.fill_rect(0, grid_oy + (b - 1) * cell, width, cell, bg_colors[b])
+  local bands = 6
+  local y = 0
+  for b = 1, bands do
+    local y1 = height * b // bands
+    local idx = 1 + (b - 1) * (BG_BANDS - 1) // (bands - 1)
+    if idx < 1 then idx = 1 end
+    if idx > BG_BANDS then idx = BG_BANDS end
+    display.fill_rect(0, y, width, y1 - y, bg_colors[idx])
+    y = y1
   end
 end
 
@@ -922,48 +934,28 @@ local function draw_live_index(i, offset_x, offset_y)
   scratch_color.r = color_r[i]
   scratch_color.g = color_g[i]
   scratch_color.b = color_b[i]
-
   local core = scratch_color
   if pulse[i] > 0 then
     local t = pulse[i] / BIRTH_PULSE_FRAMES
     core = mix_rgb_into(scratch_core, scratch_color, WHITE, 0.10 + t * 0.12)
-  end
-
-  if pulse[i] > 0 then
     local size = pulse[i] == 3 and math.max(2, cell // 4)
       or (pulse[i] == 2 and math.max(3, cell // 2) or cell)
-    clear_cell_index(i)
     display.fill_rect(px + (cell - size) // 2, py + (cell - size) // 2, size, size, core)
     return
   end
-
-  -- At 9 px the inset is still subtle; one fill keeps the ~900-cell path fast.
-  if cell <= 10 then
-    display.fill_rect(px, py, cell, cell, core)
-    return
-  end
-
-  local base = mix_rgb_into(scratch_base, INK, core, 0.58)
-  display.fill_rect(px, py, cell, cell, base)
-
-  local inset = (cell >= 5) and 1 or 0
-  if inset > 0 and cell - inset * 2 > 0 then
-    display.fill_rect(px + inset, py + inset, cell - inset * 2, cell - inset * 2, core)
-  else
-    display.fill_rect(px, py, cell, cell, core)
-  end
-
+  display.fill_rect(px, py, cell, cell, core)
 end
 
-local function draw_fade_index(i)
+local function draw_fade_index(i, offset_x, offset_y)
   scratch_fade.r = fade_r[i]
   scratch_fade.g = fade_g[i]
   scratch_fade.b = fade_b[i]
-  clear_cell_index(i)
   local size = fade_age[i] >= 2 and math.max(3, cell * 3 // 4) or math.max(2, cell // 3)
   local x = (i - 1) % grid_w
   local y = (i - 1) // grid_w
   local px, py = cell_px(x, y)
+  px = px + (offset_x or 0)
+  py = py + (offset_y or 0)
   display.fill_rect(px + (cell - size) // 2, py + (cell - size) // 2, size, size, scratch_fade)
 end
 
@@ -1002,7 +994,17 @@ end
 local function draw_scene(offset_x, offset_y)
   draw_background()
   for li = 1, #live_list do
-    draw_live_index(live_list[li], offset_x, offset_y)
+    local i = live_list[li]
+    draw_live_index(i, offset_x, offset_y)
+    if pulse[i] > 0 then
+      pulse[i] = pulse[i] - 1
+    end
+  end
+  for i = 1, n_cells do
+    if cells[i] == 0 and fade_age[i] > 0 then
+      draw_fade_index(i, offset_x, offset_y)
+      fade_age[i] = fade_age[i] - 1
+    end
   end
 end
 
@@ -1156,10 +1158,9 @@ local function draw_shaken_scene()
 end
 
 local function draw_event_feedback()
-  if event_feedback_ms <= 0 then return end
-  local level = math.max(1, math.ceil(event_feedback_ms / 60))
-  if level == event_feedback_draw_level then return end
-  event_feedback_draw_level = level
+  if event_feedback_ms <= 0 then
+    return
+  end
   local energy = clamp(event_feedback_ms / 180, 0, 1)
   local outer = mix_rgb_into(scratch_edge_outer, INK, event_feedback_color, 0.20 + 0.52 * energy)
   local inner = mix_rgb_into(scratch_edge_inner, INK, event_feedback_color, 0.08 + 0.30 * energy)
@@ -1194,9 +1195,19 @@ local function draw_world(with_glow)
 end
 
 local function render(force_glow)
-  draw_world(force_glow == true)
+  display.begin_frame({ clear = true, color = INK })
+  if shake_fx_ms > 0 then
+    draw_shaken_scene()
+  else
+    draw_scene(0, 0)
+  end
   draw_event_feedback()
   display.present()
+  display.end_frame()
+  need_full_redraw = false
+  clear_dirty()
+  world_dirty = false
+  rendered_frames = rendered_frames + 1
   last_display_ms = 0
 end
 
@@ -1245,11 +1256,14 @@ local function init_imu()
     return false
   end
 
-  -- Generic board_manager device name. Works on any board that declares an IMU
-  -- as `imu_sensor` (or override via args.imu_device). No chip/board branching.
-  local opened, sensor_or_err = pcall(imu.new, imu_device_name)
-  if not opened then
-    print("[mosaico] INFO: imu.new(" .. imu_device_name .. ") failed: " .. tostring(sensor_or_err))
+  -- Other Mosaico skills open IMU with imu.new() and no name. Named
+  -- imu_sensor is only a fallback for boards that require it.
+  local opened, sensor_or_err = pcall(imu.new)
+  if not opened or not sensor_or_err then
+    opened, sensor_or_err = pcall(imu.new, imu_device_name)
+  end
+  if not opened or not sensor_or_err then
+    print("[mosaico] INFO: imu.new failed: " .. tostring(sensor_or_err))
     return false
   end
 
@@ -1460,7 +1474,6 @@ end
 
 init_imu()
 
-display.begin_frame({ clear = true, color = INK })
 seed_demo()
 mark_scene_dirty()
 render(true)
@@ -1481,8 +1494,18 @@ else
 end
 
 local function main_loop()
-  local ticks = math.max(1, RUN_TIME_MS // FRAME_MS)
-  for _ = 1, ticks do
+  local ticks = 0
+  if RUN_TIME_MS > 0 then
+    ticks = math.max(1, RUN_TIME_MS // FRAME_MS)
+  end
+  local n = 0
+  while true do
+    if ticks > 0 then
+      n = n + 1
+      if n > ticks then
+        break
+      end
+    end
     local ok_input = true
     if input_mode == "lcd_touch" then
       ok_input = poll_touch()
@@ -1534,6 +1557,10 @@ local function main_loop()
       render(false)
     end
 
+    tick_count = tick_count + 1
+    if tick_count % 1000 == 0 then
+      print(string.format("[mosaico] FPS_STATS ticks=%d frames=%d gens=%d", tick_count, rendered_frames, generation))
+    end
     delay.delay_ms(FRAME_MS)
   end
 end


### PR DESCRIPTION
## Summary
- Adapt `game_of_life` for **Mosaico QSPI AMOLED** (CO5300-class / 480×480 GRAM): paced full-frame `begin_frame` → draw → `present` → `end_frame`, matching the command-mode bandwidth limit (~450 KB RGB565/frame).
- Document that **shake / IMU is temporarily unavailable** on current Mosaico firmware because the Lua `imu` module is not registered (`pcall(require, imu)` fails), even though the board has hardware IMU. Soft-require path is kept for boards that expose Lua IMU later.
- Update `SKILL.md` / gameplay notes accordingly for Skills Lab consumers.

## Test plan
- [ ] Install/update `skills/game_of_life` on a Mosaico board and launch from Works
- [ ] Confirm touch: tap seed / drag paint / long-press reset still work
- [ ] Confirm display uses full-frame present without hanging on open
- [ ] Confirm shake does nothing on current Mosaico image (expected) and does not crash launch
- [ ] Skills Lab online try / simulator still loads `scripts/mosaico_life.lua` if applicable
